### PR TITLE
Add FAST GetAttribute methods.

### DIFF
--- a/src/FastEnum.Benchmark/Models/Enums.cs
+++ b/src/FastEnum.Benchmark/Models/Enums.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System.ComponentModel;
+using System.Runtime.Serialization;
 
 
 
@@ -8,7 +9,7 @@ namespace FastEnum.Benchmark.Models
     {
         Unknown = 0,
 
-        [EnumMember(Value = "🍎")]
+        [EnumMember(Value = "🍎"), Description("It is a rose family")]
         Apple,
         Banana,
         Peach,

--- a/src/FastEnum.Benchmark/Models/Enums.cs
+++ b/src/FastEnum.Benchmark/Models/Enums.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Runtime.Serialization;
 
 
@@ -9,7 +10,7 @@ namespace FastEnum.Benchmark.Models
     {
         Unknown = 0,
 
-        [EnumMember(Value = "🍎"), Description("It is a rose family")]
+        [EnumMember(Value = "🍎"), Description("It is a rose family"), Color("Red"), Color("green")]
         Apple,
         Banana,
         Peach,
@@ -22,5 +23,19 @@ namespace FastEnum.Benchmark.Models
         WaterMelon,
         Pear,
         Pineapple,
+    }
+
+    /// <summary>
+    /// Sample AllowMultiple Attribute 
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, Inherited = false, AllowMultiple = true)]
+    public sealed class ColorAttribute : Attribute
+    {
+        public string Color { get; }
+
+        public ColorAttribute(string Color)
+        {
+            this.Color = Color;
+        }
     }
 }

--- a/src/FastEnum.Benchmark/Program.cs
+++ b/src/FastEnum.Benchmark/Program.cs
@@ -11,7 +11,7 @@ namespace FastEnum.Benchmark
         static void Main(string[] args)
         {
             var switcher = new BenchmarkSwitcher(new[]
-            {
+                {
                 typeof(GetValuesBenchmark),
                 typeof(GetNamesBenchmark),
                 typeof(GetNameBenchmark),
@@ -26,6 +26,7 @@ namespace FastEnum.Benchmark
                 typeof(DictionaryStringKeyBenchmark),
                 typeof(EnumMemberAttributeBenchmark),
                 typeof(EnumAttributeBenchmark),
+                typeof(EnumAttributesBenchmark),
             });
             switcher.Run(args, new BenchmarkConfig());
         }

--- a/src/FastEnum.Benchmark/Program.cs
+++ b/src/FastEnum.Benchmark/Program.cs
@@ -25,6 +25,7 @@ namespace FastEnum.Benchmark
                 typeof(DictionaryIntKeyBenchmark),
                 typeof(DictionaryStringKeyBenchmark),
                 typeof(EnumMemberAttributeBenchmark),
+                typeof(EnumAttributeBenchmark),
             });
             switcher.Run(args, new BenchmarkConfig());
         }

--- a/src/FastEnum.Benchmark/Scenarios/EnumAttributeBenchmark.cs
+++ b/src/FastEnum.Benchmark/Scenarios/EnumAttributeBenchmark.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using EnumsNET;
+using FastEnum.Benchmark.Models;
+using _FastEnum = FastEnum.FastEnum;
+
+namespace FastEnum.Benchmark.Scenarios
+{
+    public class EnumAttributeBenchmark
+    {
+        private const Fruits Value = Fruits.Apple;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _ = Enum.GetNames(typeof(Fruits));
+            _ = _FastEnum.GetNames<Fruits>();
+        }
+
+        [Benchmark(Baseline = true)]
+        public string NetCore()
+        {
+            var type = typeof(Fruits);
+            var name = Enum.GetName(type, Value);
+            var info = type.GetField(name);
+            var attr = info.GetCustomAttribute<DescriptionAttribute>();
+            return attr?.Description;
+        }
+
+        [Benchmark]
+        public string EnumsNet()
+            => Value.GetAttributes().Get<DescriptionAttribute>()?.Description;
+
+        [Benchmark]
+        public string FastEnumFromMember()
+            => Value.ToMember().GetAttribute<DescriptionAttribute>()?.Description;
+        [Benchmark]
+        public string FastEnumDirect()
+            => Value.GetAttribute<Fruits, DescriptionAttribute>()?.Description;
+    }
+}

--- a/src/FastEnum.Benchmark/Scenarios/EnumAttributesBenchmark.cs
+++ b/src/FastEnum.Benchmark/Scenarios/EnumAttributesBenchmark.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using BenchmarkDotNet.Attributes;
@@ -9,7 +10,7 @@ using _FastEnum = FastEnum.FastEnum;
 
 namespace FastEnum.Benchmark.Scenarios
 {
-    public class EnumAttributeBenchmark
+    public class EnumAttributesBenchmark
     {
         private const Fruits Value = Fruits.Apple;
 
@@ -23,24 +24,25 @@ namespace FastEnum.Benchmark.Scenarios
         }
 
         [Benchmark(Baseline = true)]
-        public string NetCore()
+        public string[] NetCore()
         {
             var type = typeof(Fruits);
             var name = Enum.GetName(type, Value);
             var info = type.GetField(name);
-            var attr = info.GetCustomAttribute<DescriptionAttribute>();
-            return attr?.Description;
+            var attr = info.GetCustomAttributes<ColorAttribute>();
+            return attr.Select(x => x.Color).ToArray();
         }
 
         [Benchmark]
-        public string EnumsNet()
-            => EnumsNET.Enums.GetAttributes(Value).Get<DescriptionAttribute>()?.Description;
+        public string[] EnumsNet()
+            => EnumsNET.Enums.GetAttributes(Value).GetAll<ColorAttribute>().Select(x => x.Color).ToArray();
 
         [Benchmark]
-        public string FastEnumFromMember()
-            => Value.ToMember().GetAttribute<DescriptionAttribute>()?.Description;
+        public string[] FastEnumFromMember()
+            => Value.ToMember().GetAttributes<ColorAttribute>().Select(x => x.Color).ToArray();
         [Benchmark]
-        public string FastEnumDirect()
-            => Value.GetAttribute<Fruits, DescriptionAttribute>()?.Description;
+        public string[] FastEnumDirect()
+            => Value.GetAttributes<Fruits, ColorAttribute>().Select(x => x.Color).ToArray();
     }
+
 }

--- a/src/FastEnum/FastEnum.cs
+++ b/src/FastEnum/FastEnum.cs
@@ -604,6 +604,21 @@ namespace FastEnum
                 x => x,
                 x => x.ToMember().FieldInfo.GetCustomAttribute<TAttribute>());
         }
+
+        /// <summary>
+        /// Provides cache for enum attributes.
+        /// </summary>
+        /// <typeparam name="T">Enum Type</typeparam>
+        /// <typeparam name="TAttribute">Attribute Type</typeparam>
+        internal static class EnumAttributesCache<T, TAttribute>
+               where T : struct, Enum
+               where TAttribute : Attribute
+        {
+            internal static FrozenDictionary<T, IReadOnlyList<TAttribute>> Cache { get; } = GetValues<T>()
+                .ToFrozenDictionary(
+                x => x,
+                x => x.ToMember().FieldInfo.GetCustomAttributes<TAttribute>().ToArray() as IReadOnlyList<TAttribute>);
+        }
         #endregion
     }
 }

--- a/src/FastEnum/FastEnum.cs
+++ b/src/FastEnum/FastEnum.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using FastEnum.Internals;
 
@@ -587,6 +588,21 @@ namespace FastEnum
                 MemberByName = Members.ToStringKeyFrozenDictionary(x => x.Name);
             }
             #endregion
+        }
+
+        /// <summary>
+        /// Provides cache for enum attributes.
+        /// </summary>
+        /// <typeparam name="T">Enum Type</typeparam>
+        /// <typeparam name="TAttribute">Attribute Type</typeparam>
+        internal static class EnumAttributeCache<T, TAttribute>
+               where T : struct, Enum
+               where TAttribute : Attribute
+        {
+            internal static FrozenDictionary<T, TAttribute> Cache { get; } = GetValues<T>()
+                .ToFrozenDictionary(
+                x => x,
+                x => x.ToMember().FieldInfo.GetCustomAttribute<TAttribute>());
         }
         #endregion
     }

--- a/src/FastEnum/FastEnumExtensions.cs
+++ b/src/FastEnum/FastEnumExtensions.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
 
@@ -100,5 +104,19 @@ namespace FastEnum
                 ? throw new NotFoundException($"{typeof(TAttribute)} is not found.")
                 : attr;
         }
+
+        /// <summary>
+        /// Gets the Attribute of specified enumration member.
+        /// </summary>
+        /// <typeparam name="T">Enum Type</typeparam>
+        /// <typeparam name="TAttribute">Attribute Type</typeparam>
+        /// <param name="value"></param>
+        /// <param name="throwIfNotFound"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IReadOnlyList<TAttribute> GetAttributes<T, TAttribute>(this T value)
+           where T : struct, Enum
+           where TAttribute : Attribute
+            => FastEnum.EnumAttributesCache<T, TAttribute>.Cache[value];
     }
 }

--- a/src/FastEnum/FastEnumExtensions.cs
+++ b/src/FastEnum/FastEnumExtensions.cs
@@ -82,5 +82,23 @@ namespace FastEnum
                 ? throw new NotFoundException($"{nameof(LabelAttribute)} that is specified index {index} is not found.")
                 : default(string);
         }
+
+        /// <summary>
+        /// Gets the Attribute of specified enumration member.
+        /// </summary>
+        /// <typeparam name="T">Enum Type</typeparam>
+        /// <typeparam name="TAttribute">Attribute Type</typeparam>
+        /// <param name="value"></param>
+        /// <param name="throwIfNotFound"></param>
+        /// <returns></returns>
+        public static TAttribute GetAttribute<T, TAttribute>(this T value, bool throwIfNotFound = true)
+            where T : struct, Enum
+            where TAttribute : Attribute
+        {
+            var attr = FastEnum.EnumAttributeCache<T, TAttribute>.Cache[value];
+            return attr == null && throwIfNotFound
+                ? throw new NotFoundException($"{typeof(TAttribute)} is not found.")
+                : attr;
+        }
     }
 }

--- a/src/FastEnum/Member.cs
+++ b/src/FastEnum/Member.cs
@@ -68,6 +68,16 @@ namespace FastEnum
         }
         #endregion
 
+        /// <summary>
+        /// Gets the Attribute of specified enumration member.
+        /// </summary>
+        /// <typeparam name="TAttribute">Attribute Type</typeparam>
+        public TAttribute GetAttribute<TAttribute>()
+            where TAttribute : Attribute
+        {
+            return FastEnum.EnumAttributeCache<T, TAttribute>.Cache[Value];
+        }
+
 
         #region Classes
         /// <summary>

--- a/src/FastEnum/Member.cs
+++ b/src/FastEnum/Member.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using FastEnum.Internals;
 
@@ -72,12 +73,19 @@ namespace FastEnum
         /// Gets the Attribute of specified enumration member.
         /// </summary>
         /// <typeparam name="TAttribute">Attribute Type</typeparam>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TAttribute GetAttribute<TAttribute>()
             where TAttribute : Attribute
-        {
-            return FastEnum.EnumAttributeCache<T, TAttribute>.Cache[Value];
-        }
+            => FastEnum.EnumAttributeCache<T, TAttribute>.Cache[Value];
 
+        /// <summary>
+        /// Gets the Attributes of specified enumration member.
+        /// </summary>
+        /// <typeparam name="TAttribute">Attribute Type</typeparam>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IReadOnlyList<TAttribute> GetAttributes<TAttribute>()
+            where TAttribute : Attribute
+            => FastEnum.EnumAttributesCache<T, TAttribute>.Cache[Value];
 
         #region Classes
         /// <summary>


### PR DESCRIPTION
Hi,

This PR is adding **fast** GetAttribute methods.

# How to use

```csharp
//from Member 
Fruits.Apple.ToMember().GetAttribute<DescriptionAttribute>()?.Description;

//Direct: it is little bit faster, but verbose(`<Fruits`).
Fruits.Apple.GetAttribute<Fruits, DescriptionAttribute>()?.Description;
```

# Benchmark

|             Method |        Mean |      Error |    StdDev | Ratio |
|------------------- |------------:|-----------:|----------:|------:|
|            NetCore | 1,308.74 ns | 119.295 ns | 6.5390 ns | 1.000 |
|           EnumsNet |    24.24 ns |   2.391 ns | 0.1310 ns | 0.019 |
| FastEnumFromMember |    17.09 ns |   2.669 ns | 0.1463 ns | 0.013 |
|     FastEnumDirect |    11.42 ns |   2.344 ns | 0.1285 ns | 0.009 |