### PR TITLE
Prevent internal cache editing using downcast.

### DIFF
--- a/src/FastEnum.Benchmark/Program.cs
+++ b/src/FastEnum.Benchmark/Program.cs
@@ -25,6 +25,7 @@ namespace FastEnumUtility.Benchmark
                 typeof(DictionaryIntKeyBenchmark),
                 typeof(DictionaryStringKeyBenchmark),
                 typeof(EnumMemberAttributeBenchmark),
+                typeof(ForEachBenchmark),
             });
             switcher.Run(args, new BenchmarkConfig());
         }

--- a/src/FastEnum.Benchmark/Scenarios/ForEachBenchmark.cs
+++ b/src/FastEnum.Benchmark/Scenarios/ForEachBenchmark.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using FastEnumUtility.Internals;
+
+
+
+namespace FastEnumUtility.Benchmark.Scenarios
+{
+    public class ForEachBenchmark
+    {
+        private ReadOnlyArray<int> _ReadOnlyArray { get; set; }
+        private ReadOnlyCollection<int> _ReadOnlyCollection { get; set; }
+        private IReadOnlyList<int> _IReadOnlyList { get; set; }
+        private List<int> _List { get; set; }
+        private int[] _Array { get; set; }
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var raw = Enumerable.Range(1, 100);
+            this._ReadOnlyArray = new ReadOnlyArray<int>(raw.ToArray());
+            this._ReadOnlyCollection = new ReadOnlyCollection<int>(raw.ToList());
+            this._IReadOnlyList = raw.ToArray();
+            this._List = raw.ToList();
+            this._Array = raw.ToArray();
+        }
+
+
+        [Benchmark(Baseline = true)]
+        public int Array()
+        {
+            var sum = 0;
+            foreach (var x in this._Array)
+                sum += x;
+            return sum;
+        }
+
+
+        [Benchmark]
+        public int List()
+        {
+            var sum = 0;
+            foreach (var x in this._List)
+                sum += x;
+            return sum;
+        }
+
+
+        [Benchmark]
+        public int ReadOnlyCollection()
+        {
+            var sum = 0;
+            foreach (var x in this._ReadOnlyCollection)
+                sum += x;
+            return sum;
+        }
+
+
+        [Benchmark]
+        public int IReadOnlyList()
+        {
+            var sum = 0;
+            foreach (var x in this._IReadOnlyList)
+                sum += x;
+            return sum;
+        }
+
+
+        [Benchmark]
+        public int ReadOnlyArray()
+        {
+            var sum = 0;
+            foreach (var x in this._ReadOnlyArray)
+                sum += x;
+            return sum;
+        }
+    }
+}

--- a/src/FastEnum.Tests/Cases/ReadOnlyArrayTest.cs
+++ b/src/FastEnum.Tests/Cases/ReadOnlyArrayTest.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using FastEnumUtility.Internals;
+using FluentAssertions;
+using Xunit;
+
+
+
+namespace FastEnumUtility.Tests.Cases
+{
+    public class ReadOnlyArrayTest
+    {
+        private const int LoopCount = 100;
+        private readonly int[] SourceArray = Enumerable.Range(0, LoopCount).ToArray();
+
+
+        [Fact]
+        public void Count()
+        {
+            var roa = this.SourceArray.ToReadOnlyArray();
+            roa.Count.Should().Be(this.SourceArray.Length);
+        }
+
+
+        [Fact]
+        public void ForEach()
+        {
+            var sum = 0;
+            foreach (var x in this.SourceArray.ToReadOnlyArray())
+                sum += x;
+
+            sum.Should().Be(this.SourceArray.Sum());
+        }
+
+
+        [Fact]
+        public void SequenceEquals()
+        {
+            var roa = this.SourceArray.ToReadOnlyArray();
+            roa.Should().BeEquivalentTo(this.SourceArray);
+            roa.Should().ContainInOrder(this.SourceArray);
+        }
+    }
+}

--- a/src/FastEnum/FastEnum.cs
+++ b/src/FastEnum/FastEnum.cs
@@ -467,9 +467,9 @@ namespace FastEnumUtility
             #region Fields
             public static readonly Type Type;
             public static readonly Type UnderlyingType;
-            public static readonly T[] Values;
-            public static readonly string[] Names;
-            public static readonly Member<T>[] Members;
+            public static readonly ReadOnlyArray<T> Values;
+            public static readonly ReadOnlyArray<string> Names;
+            public static readonly ReadOnlyArray<Member<T>> Members;
             public static readonly T MinValue;
             public static readonly T MaxValue;
             public static readonly bool IsEmpty;
@@ -486,12 +486,12 @@ namespace FastEnumUtility
             {
                 Type = typeof(T);
                 UnderlyingType = Enum.GetUnderlyingType(Type);
-                Values = Enum.GetValues(Type) as T[];
-                Names = Enum.GetNames(Type).Select(string.Intern).ToArray();
-                Members = Names.Select(x => new Member<T>(x)).ToArray();
+                Values = (Enum.GetValues(Type) as T[]).AsReadOnly();
+                Names = Enum.GetNames(Type).Select(string.Intern).ToReadOnlyArray();
+                Members = Names.Select(x => new Member<T>(x)).ToReadOnlyArray();
                 MinValue = Values.DefaultIfEmpty().Min();
                 MaxValue = Values.DefaultIfEmpty().Max();
-                IsEmpty = Values.Length == 0;
+                IsEmpty = Values.Count == 0;
                 IsFlags = Attribute.IsDefined(Type, typeof(FlagsAttribute));
                 MemberByValue = Members.Distinct(new Member<T>.ValueComparer()).ToFrozenDictionary(x => x.Value);
                 MemberByName = Members.ToFrozenStringKeyDictionary(x => x.Name);

--- a/src/FastEnum/Internals/ReadOnlyArray.cs
+++ b/src/FastEnum/Internals/ReadOnlyArray.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+
+
+namespace FastEnumUtility.Internals
+{
+    /// <summary>
+    /// Provides the readonly array.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal sealed class ReadOnlyArray<T> : IReadOnlyList<T>
+    {
+        #region Fields
+        private readonly T[] source;
+        #endregion
+
+
+        #region Constructors
+        /// <summary>
+        /// Creates instance.
+        /// </summary>
+        /// <param name="source"></param>
+        public ReadOnlyArray(T[] source)
+            => this.source = source ?? throw new ArgumentNullException(nameof(source));
+        #endregion
+
+
+        #region Custom enumerator
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public Enumerator GetEnumerator()
+            => new Enumerator(this.source);
+        #endregion
+
+
+        #region IReadOnlyList<T> implementations
+        /// <summary>
+        /// Gets the element at the specified index in the read-only list.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to get.</param>
+        /// <returns>The element at the specified index in the read-only list.</returns>
+        public T this[int index]
+            => this.source[index];
+
+
+        /// <summary>
+        /// Gets the number of elements in the collection.
+        /// </summary>
+        public int Count
+            => this.source.Length;
+
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+            => new RefEnumerator(this.source);
+
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerator"/> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+            => this.source.GetEnumerator();
+        #endregion
+
+
+        #region Enumerator
+        /// <summary>
+        /// Provides an enumerator as value type that iterates through the collection.
+        /// </summary>
+        public struct Enumerator : IEnumerator<T>
+        {
+            #region Fields
+            private readonly T[] source;
+            private int index;
+            #endregion
+
+
+            #region Constructors
+            internal Enumerator(T[] source)
+            {
+                this.source = source;
+                this.index = -1;
+            }
+            #endregion
+
+
+            #region IEnumerator<T> implementations
+            public T Current
+                => this.source[this.index];
+
+
+            object IEnumerator.Current
+                => this.Current;
+
+
+            public void Dispose()
+            { }
+
+
+            public bool MoveNext()
+            {
+                this.index++;
+                return (uint)this.index < (uint)this.source.Length;
+            }
+
+
+            public void Reset()
+                => this.index = -1;
+            #endregion
+        }
+
+
+        /// <summary>
+        /// Provides an enumerator as reference type that iterates through the collection.
+        /// </summary>
+        internal class RefEnumerator : IEnumerator<T>
+        {
+            #region Fields
+            private readonly T[] source;
+            private int index;
+            #endregion
+
+
+            #region Constructors
+            internal RefEnumerator(T[] source)
+            {
+                this.source = source;
+                this.index = -1;
+            }
+            #endregion
+
+
+            #region IEnumerator<T> implementations
+            public T Current
+                => this.source[this.index];
+
+
+            object IEnumerator.Current
+                => this.Current;
+
+
+            public void Dispose()
+            { }
+
+
+            public bool MoveNext()
+            {
+                this.index++;
+                return (uint)this.index < (uint)this.source.Length;
+            }
+
+
+            public void Reset()
+                => this.index = -1;
+            #endregion
+        }
+        #endregion
+    }
+
+
+
+    /// <summary>
+    /// Provides <see cref="ReadOnlyArray{T}"/> extension methods.
+    /// </summary>
+    internal static class ReadOnlyArrayExtensions
+    {
+        /// <summary>
+        /// Converts to <see cref="ReadOnlyArray{T}"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static ReadOnlyArray<T> ToReadOnlyArray<T>(this IEnumerable<T> source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            return source is T[] array
+                ? new ReadOnlyArray<T>(array)
+                : new ReadOnlyArray<T>(source.ToArray());
+        }
+
+
+        /// <summary>
+        /// Converts to <see cref="ReadOnlyArray{T}"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static ReadOnlyArray<T> AsReadOnly<T>(this T[] source)
+            => new ReadOnlyArray<T>(source);
+    }
+}


### PR DESCRIPTION
# Overview
Currently, `FastEnum.GetValues<T>()` returns internal cache as `IReadOnlyList<T>` type. Generally, user *can't* edit it. However if downcast it as `T[]`, internal cache be able to be edited. It's very unfortunate that user can easily edit the internal cache, so this Pull-Request prevent it.


# Related issue
- Cache の Values, Names, Members の要素が書き換え可能 (#3) 


# Implementation
- Add `ReadOnlyArray<T>` as internal class
- Internal cache holds as `ReadOnlyArray<T>`
- Returns `ReadOnlyArray<T>` as `IReadOnlyList<T>`
    - No breaking changes
    - Ideally it should return `ReadOnlyArray<T>`, but I wanna wait until .NET Core adds something similar  in the future