### PR TITLE
Add net461 target framework

### DIFF
--- a/src/FastEnum/FastEnum.csproj
+++ b/src/FastEnum/FastEnum.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
         <RootNamespace>FastEnumUtility</RootNamespace>
         <LangVersion>8.0</LangVersion>
         <Nullable>disable</Nullable>
@@ -27,6 +27,10 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="System.Memory" Version="4.5.4" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
         <PackageReference Include="System.Memory" Version="4.5.4" />
     </ItemGroup>
 


### PR DESCRIPTION
This PR adds the net461 target framework. This enables adding FastEnum to legacy projects targeting .NET Framework 4.6.1 / 4.6.2 / 4.7 without having to ship many additional system DLLs (see dotnet/standard#545).