### PR TITLE
Return `ImmutableArray<T>`

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,5 +9,6 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="MSTest" Version="3.5.2" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/insights/FastEnum.UnitTests/Cases/BasicTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/BasicTests.cs
@@ -78,7 +78,7 @@ public sealed class SByteTests
             .ToArray();
         var actual = FastEnum.GetMembers<SByteEnum>();
 
-        actual.Count.Should().Be(expect.Length);
+        actual.Length.Should().Be(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
@@ -424,7 +424,7 @@ public sealed class ByteTests
             .ToArray();
         var actual = FastEnum.GetMembers<ByteEnum>();
 
-        actual.Count.Should().Be(expect.Length);
+        actual.Length.Should().Be(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
@@ -762,7 +762,7 @@ public sealed class Int16Tests
             .ToArray();
         var actual = FastEnum.GetMembers<Int16Enum>();
 
-        actual.Count.Should().Be(expect.Length);
+        actual.Length.Should().Be(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
@@ -1108,7 +1108,7 @@ public sealed class UInt16Tests
             .ToArray();
         var actual = FastEnum.GetMembers<UInt16Enum>();
 
-        actual.Count.Should().Be(expect.Length);
+        actual.Length.Should().Be(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
@@ -1446,7 +1446,7 @@ public sealed class Int32Tests
             .ToArray();
         var actual = FastEnum.GetMembers<Int32Enum>();
 
-        actual.Count.Should().Be(expect.Length);
+        actual.Length.Should().Be(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
@@ -1792,7 +1792,7 @@ public sealed class UInt32Tests
             .ToArray();
         var actual = FastEnum.GetMembers<UInt32Enum>();
 
-        actual.Count.Should().Be(expect.Length);
+        actual.Length.Should().Be(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
@@ -2130,7 +2130,7 @@ public sealed class Int64Tests
             .ToArray();
         var actual = FastEnum.GetMembers<Int64Enum>();
 
-        actual.Count.Should().Be(expect.Length);
+        actual.Length.Should().Be(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
@@ -2476,7 +2476,7 @@ public sealed class UInt64Tests
             .ToArray();
         var actual = FastEnum.GetMembers<UInt64Enum>();
 
-        actual.Count.Should().Be(expect.Length);
+        actual.Length.Should().Be(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];

--- a/src/insights/FastEnum.UnitTests/Cases/BasicTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/BasicTests.tt
@@ -97,7 +97,7 @@ public sealed class <#= x.AliasType #>Tests
             .ToArray();
         var actual = FastEnum.GetMembers<<#= x.EnumType #>>();
 
-        actual.Count.Should().Be(expect.Length);
+        actual.Length.Should().Be(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];

--- a/src/insights/FastEnum.UnitTests/Cases/SameValueTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/SameValueTests.cs
@@ -45,7 +45,7 @@ public class SameValueTests
             .ToArray();
         var actual = FastEnum.GetMembers<TEnum>();
 
-        actual.Count.Should().Be(expect.Length);
+        actual.Length.Should().Be(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];

--- a/src/libs/FastEnum.Core/FastEnum.Core.csproj
+++ b/src/libs/FastEnum.Core/FastEnum.Core.csproj
@@ -31,7 +31,7 @@
     <ItemGroup>
         <None Include="../../../README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
-    
+
     <!-- T4 Template -->
     <ItemGroup>
         <Compile Update="Internals\UnderlyingOperation.cs">

--- a/src/libs/FastEnum.Core/FastEnum.Core.csproj
+++ b/src/libs/FastEnum.Core/FastEnum.Core.csproj
@@ -4,6 +4,10 @@
         <RootNamespace>FastEnumUtility</RootNamespace>
     </PropertyGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <PackageReference Include="System.Collections.Immutable" />
+    </ItemGroup>
+
     <!-- NuGet -->
     <PropertyGroup>
         <IsPackable>true</IsPackable>

--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using FastEnumUtility.Internals;
 
 namespace FastEnumUtility;
@@ -31,9 +32,9 @@ public static class FastEnum
     /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IReadOnlyList<T> GetValues<T>()
+    public static ImmutableArray<T> GetValues<T>()
         where T : struct, Enum
-        => EnumInfo<T>.s_values;
+        => ImmutableCollectionsMarshal.AsImmutableArray(EnumInfo<T>.s_values);
 
 
     /// <summary>
@@ -42,9 +43,9 @@ public static class FastEnum
     /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IReadOnlyList<string> GetNames<T>()
+    public static ImmutableArray<string> GetNames<T>()
         where T : struct, Enum
-        => EnumInfo<T>.s_names;
+        => ImmutableCollectionsMarshal.AsImmutableArray(EnumInfo<T>.s_names);
 
 
     /// <summary>
@@ -65,9 +66,9 @@ public static class FastEnum
     /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IReadOnlyList<Member<T>> GetMembers<T>()
+    public static ImmutableArray<Member<T>> GetMembers<T>()
         where T : struct, Enum
-        => EnumInfo<T>.s_members;
+        => ImmutableCollectionsMarshal.AsImmutableArray(EnumInfo<T>.s_members);
 
 
     /// <summary>


### PR DESCRIPTION
# Summary
For the following methods, make them return `ImmutableArray<T>`. This improves user convenience, safety and performance.

- `.GetValues<T>()`
- `.GetNames<T>()`
- `.GetMembers<T>()`