### PR TITLE
Support `ReadOnlySpan<char>`

### DIFF
--- a/src/insights/FastEnum.UnitTests/Cases/BasicTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/BasicTests.cs
@@ -208,7 +208,6 @@ public sealed class SByteTests
             FastEnum.Parse<SByteEnum>(x.valueString.ToLower()).Should().Be(x.value);
             FastEnum.Parse<SByteEnum>(x.valueString.ToUpper()).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -233,7 +232,6 @@ public sealed class SByteTests
             FastEnum.Parse<SByteEnum>(x.valueString.ToLower(), true).Should().Be(x.value);
             FastEnum.Parse<SByteEnum>(x.valueString.ToUpper(), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("ABCDE", true)).Should().Throw<ArgumentException>();
@@ -553,7 +551,6 @@ public sealed class ByteTests
             FastEnum.Parse<ByteEnum>(x.valueString.ToLower()).Should().Be(x.value);
             FastEnum.Parse<ByteEnum>(x.valueString.ToUpper()).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -577,7 +574,6 @@ public sealed class ByteTests
             FastEnum.Parse<ByteEnum>(x.valueString.ToLower(), true).Should().Be(x.value);
             FastEnum.Parse<ByteEnum>(x.valueString.ToUpper(), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("ABCDE", true)).Should().Throw<ArgumentException>();
@@ -898,7 +894,6 @@ public sealed class Int16Tests
             FastEnum.Parse<Int16Enum>(x.valueString.ToLower()).Should().Be(x.value);
             FastEnum.Parse<Int16Enum>(x.valueString.ToUpper()).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -923,7 +918,6 @@ public sealed class Int16Tests
             FastEnum.Parse<Int16Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
             FastEnum.Parse<Int16Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
@@ -1243,7 +1237,6 @@ public sealed class UInt16Tests
             FastEnum.Parse<UInt16Enum>(x.valueString.ToLower()).Should().Be(x.value);
             FastEnum.Parse<UInt16Enum>(x.valueString.ToUpper()).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -1267,7 +1260,6 @@ public sealed class UInt16Tests
             FastEnum.Parse<UInt16Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
             FastEnum.Parse<UInt16Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
@@ -1588,7 +1580,6 @@ public sealed class Int32Tests
             FastEnum.Parse<Int32Enum>(x.valueString.ToLower()).Should().Be(x.value);
             FastEnum.Parse<Int32Enum>(x.valueString.ToUpper()).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -1613,7 +1604,6 @@ public sealed class Int32Tests
             FastEnum.Parse<Int32Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
             FastEnum.Parse<Int32Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
@@ -1933,7 +1923,6 @@ public sealed class UInt32Tests
             FastEnum.Parse<UInt32Enum>(x.valueString.ToLower()).Should().Be(x.value);
             FastEnum.Parse<UInt32Enum>(x.valueString.ToUpper()).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -1957,7 +1946,6 @@ public sealed class UInt32Tests
             FastEnum.Parse<UInt32Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
             FastEnum.Parse<UInt32Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
@@ -2278,7 +2266,6 @@ public sealed class Int64Tests
             FastEnum.Parse<Int64Enum>(x.valueString.ToLower()).Should().Be(x.value);
             FastEnum.Parse<Int64Enum>(x.valueString.ToUpper()).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -2303,7 +2290,6 @@ public sealed class Int64Tests
             FastEnum.Parse<Int64Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
             FastEnum.Parse<Int64Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
@@ -2623,7 +2609,6 @@ public sealed class UInt64Tests
             FastEnum.Parse<UInt64Enum>(x.valueString.ToLower()).Should().Be(x.value);
             FastEnum.Parse<UInt64Enum>(x.valueString.ToUpper()).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -2647,7 +2632,6 @@ public sealed class UInt64Tests
             FastEnum.Parse<UInt64Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
             FastEnum.Parse<UInt64Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("ABCDE", true)).Should().Throw<ArgumentException>();

--- a/src/insights/FastEnum.UnitTests/Cases/BasicTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/BasicTests.tt
@@ -235,7 +235,6 @@ public sealed class <#= x.AliasType #>Tests
             FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToLower()).Should().Be(x.value);
             FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToUpper()).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE")).Should().Throw<ArgumentException>();
@@ -262,7 +261,6 @@ public sealed class <#= x.AliasType #>Tests
             FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToLower(), true).Should().Be(x.value);
             FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToUpper(), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", true)).Should().Throw<ArgumentException>();

--- a/src/insights/FastEnum.UnitTests/Cases/EmptyTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/EmptyTests.cs
@@ -66,7 +66,6 @@ public class EmptyTests
     [TestMethod]
     public void Parse()
     {
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -76,7 +75,6 @@ public class EmptyTests
     [TestMethod]
     public void ParseIgnoreCase()
     {
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE", true)).Should().Throw<ArgumentException>();

--- a/src/insights/FastEnum.UnitTests/Cases/SameValueTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/SameValueTests.cs
@@ -112,7 +112,6 @@ public class SameValueTests
             FluentActions.Invoking(() => FastEnum.Parse<TEnum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
             FluentActions.Invoking(() => FastEnum.Parse<TEnum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(null!)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(string.Empty)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ")).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -137,7 +136,6 @@ public class SameValueTests
             FastEnum.Parse<TEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<TEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(null!, true)).Should().Throw<ArgumentNullException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(string.Empty, true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE", true)).Should().Throw<ArgumentException>();

--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -141,7 +141,7 @@ public static class FastEnum
     /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsDefined<T>(string name)
+    public static bool IsDefined<T>(ReadOnlySpan<char> name)
         where T : struct, Enum
         => EnumInfo<T>.s_memberByNameCaseSensitive.ContainsKey(name);
 
@@ -179,7 +179,7 @@ public static class FastEnum
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="ArgumentNullException"></exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T Parse<T>(string value)
+    public static T Parse<T>(ReadOnlySpan<char> value)
         where T : struct, Enum
         => Parse<T>(value, false);
 
@@ -195,10 +195,9 @@ public static class FastEnum
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="ArgumentNullException"></exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T Parse<T>(string value, bool ignoreCase)
+    public static T Parse<T>(ReadOnlySpan<char> value, bool ignoreCase)
         where T : struct, Enum
     {
-        ArgumentNullException.ThrowIfNull(value);
         if (!TryParse<T>(value, ignoreCase, out var result))
             ThrowHelper.ThrowValueNotDefined(value, nameof(value));
         return result;
@@ -214,7 +213,7 @@ public static class FastEnum
     /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
     /// <returns>true if the value parameter was converted successfully; otherwise, false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool TryParse<T>(string? value, out T result)
+    public static bool TryParse<T>(ReadOnlySpan<char> value, out T result)
         where T : struct, Enum
         => TryParse(value, false, out result);
 
@@ -230,10 +229,10 @@ public static class FastEnum
     /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
     /// <returns>true if the value parameter was converted successfully; otherwise, false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool TryParse<T>(string? value, bool ignoreCase, out T result)
+    public static bool TryParse<T>(ReadOnlySpan<char> value, bool ignoreCase, out T result)
         where T : struct, Enum
     {
-        if (string.IsNullOrEmpty(value))
+        if (value.IsEmpty)
         {
             result = default;
             return false;
@@ -255,7 +254,7 @@ public static class FastEnum
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool tryParseNameCaseSensitive(string name, out T result)
+        static bool tryParseNameCaseSensitive(ReadOnlySpan<char> name, out T result)
         {
             if (EnumInfo<T>.s_memberByNameCaseSensitive.TryGetValue(name, out var member))
             {
@@ -268,7 +267,7 @@ public static class FastEnum
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool tryParseNameCaseInsensitive(string name, out T result)
+        static bool tryParseNameCaseInsensitive(ReadOnlySpan<char> name, out T result)
         {
             if (EnumInfo<T>.s_memberByNameCaseInsensitive.TryGetValue(name, out var member))
             {

--- a/src/libs/FastEnum.Core/Internals/FastReadOnlyDictionary.cs
+++ b/src/libs/FastEnum.Core/Internals/FastReadOnlyDictionary.cs
@@ -222,7 +222,7 @@ internal sealed class StringOrdinalCaseSensitiveDictionary<TValue>
 
         static bool tryAdd(Entry[] buckets, Entry entry, int indexFor)
         {
-            var hash = StringHelpers.GetHashCode(entry.Key);
+            var hash = CaseSensitiveStringHelpers.GetHashCode(entry.Key);
             var index = hash & indexFor;
             var target = buckets[index];
             if (target is null)
@@ -235,7 +235,7 @@ internal sealed class StringOrdinalCaseSensitiveDictionary<TValue>
             while (true)
             {
                 //--- Check duplicate
-                if (StringHelpers.Equals(target.Key, entry.Key))
+                if (CaseSensitiveStringHelpers.Equals(target.Key, entry.Key))
                     return false;
 
                 //--- Append entry
@@ -266,12 +266,12 @@ internal sealed class StringOrdinalCaseSensitiveDictionary<TValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryGetValue(ReadOnlySpan<char> key, [MaybeNullWhen(false)] out TValue value)
     {
-        var hash = StringHelpers.GetHashCode(key);
+        var hash = CaseSensitiveStringHelpers.GetHashCode(key);
         var index = hash & this._indexFor;
         var entry = this._buckets[index];
         while (entry is not null)
         {
-            if (StringHelpers.Equals(key, entry.Key))
+            if (CaseSensitiveStringHelpers.Equals(key, entry.Key))
             {
                 value = entry.Value;
                 return true;
@@ -362,7 +362,7 @@ internal sealed class StringOrdinalCaseInsensitiveDictionary<TValue>
 
         static bool tryAdd(Entry[] buckets, Entry entry, int indexFor)
         {
-            var hash = StringHelpers.GetHashCodeOrdinalIgnoreCase(entry.Key);
+            var hash = CaseInsensitiveStringHelpers.GetHashCode(entry.Key);
             var index = hash & indexFor;
             var target = buckets[index];
             if (target is null)
@@ -375,7 +375,7 @@ internal sealed class StringOrdinalCaseInsensitiveDictionary<TValue>
             while (true)
             {
                 //--- Check duplicate
-                if (StringHelpers.EqualsOrdinalIgnoreCase(target.Key, entry.Key))
+                if (CaseInsensitiveStringHelpers.Equals(target.Key, entry.Key))
                     return false;
 
                 //--- Append entry
@@ -406,12 +406,12 @@ internal sealed class StringOrdinalCaseInsensitiveDictionary<TValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryGetValue(ReadOnlySpan<char> key, [MaybeNullWhen(false)] out TValue value)
     {
-        var hash = StringHelpers.GetHashCodeOrdinalIgnoreCase(key);
+        var hash = CaseInsensitiveStringHelpers.GetHashCode(key);
         var index = hash & this._indexFor;
         var entry = this._buckets[index];
         while (entry is not null)
         {
-            if (StringHelpers.EqualsOrdinalIgnoreCase(entry.Key, key))
+            if (CaseInsensitiveStringHelpers.Equals(entry.Key, key))
             {
                 value = entry.Value;
                 return true;
@@ -472,7 +472,7 @@ internal static class SpecializedDictionaryExtensions
 
 
 
-file static class StringHelpers
+file static class CaseSensitiveStringHelpers
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetHashCode(ReadOnlySpan<char> value)
@@ -490,10 +490,14 @@ file static class StringHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool Equals(ReadOnlySpan<char> x, ReadOnlySpan<char> y)
         => MemoryExtensions.SequenceEqual(x, y);
+}
 
 
+
+file static class CaseInsensitiveStringHelpers
+{
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int GetHashCodeOrdinalIgnoreCase(ReadOnlySpan<char> value)
+    public static int GetHashCode(ReadOnlySpan<char> value)
     {
 #if NET8_0_OR_GREATER
         return GetHashCodeOrdinalIgnoreCase(self: null, value);
@@ -504,7 +508,7 @@ file static class StringHelpers
 
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool EqualsOrdinalIgnoreCase(ReadOnlySpan<char> x, ReadOnlySpan<char> y)
+    public static bool Equals(ReadOnlySpan<char> x, ReadOnlySpan<char> y)
         => MemoryExtensions.Equals(x, y, StringComparison.OrdinalIgnoreCase);
 
 

--- a/src/libs/FastEnum.Core/Internals/FastReadOnlyDictionary.cs
+++ b/src/libs/FastEnum.Core/Internals/FastReadOnlyDictionary.cs
@@ -448,7 +448,6 @@ internal sealed class StringOrdinalCaseInsensitiveDictionary<TValue>
 
 
 
-
 internal static class SpecializedDictionaryExtensions
 {
     #region FastReadOnlyDictionary

--- a/src/libs/FastEnum.Core/Internals/FastReadOnlyDictionary.cs
+++ b/src/libs/FastEnum.Core/Internals/FastReadOnlyDictionary.cs
@@ -374,7 +374,7 @@ internal sealed class StringOrdinalCaseInsensitiveDictionary<TValue>
 
         static bool tryAdd(Entry[] buckets, Entry entry, int indexFor)
         {
-            var hash = StringAccessor.GetHashCodeOrdinalIgnoreCase(entry.Key);
+            var hash = StringHelpers.GetHashCodeOrdinalIgnoreCase(entry.Key);
             var index = hash & indexFor;
             var target = buckets[index];
             if (target is null)
@@ -387,7 +387,7 @@ internal sealed class StringOrdinalCaseInsensitiveDictionary<TValue>
             while (true)
             {
                 //--- Check duplicate
-                if (StringAccessor.EqualsOrdinalIgnoreCase(target.Key, entry.Key))
+                if (StringHelpers.EqualsOrdinalIgnoreCase(target.Key, entry.Key))
                     return false;
 
                 //--- Append entry
@@ -418,12 +418,12 @@ internal sealed class StringOrdinalCaseInsensitiveDictionary<TValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryGetValue(ReadOnlySpan<char> key, [MaybeNullWhen(false)] out TValue value)
     {
-        var hash = StringAccessor.GetHashCodeOrdinalIgnoreCase(key);
+        var hash = StringHelpers.GetHashCodeOrdinalIgnoreCase(key);
         var index = hash & this._indexFor;
         var entry = this._buckets[index];
         while (entry is not null)
         {
-            if (StringAccessor.EqualsOrdinalIgnoreCase(entry.Key, key))
+            if (StringHelpers.EqualsOrdinalIgnoreCase(entry.Key, key))
             {
                 value = entry.Value;
                 return true;
@@ -484,7 +484,7 @@ internal static class SpecializedDictionaryExtensions
 
 
 
-file static class StringAccessor
+file static class StringHelpers
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetHashCodeOrdinalIgnoreCase(ReadOnlySpan<char> value)

--- a/src/libs/FastEnum.Core/Internals/ThrowHelper.cs
+++ b/src/libs/FastEnum.Core/Internals/ThrowHelper.cs
@@ -25,7 +25,7 @@ internal static class ThrowHelper
 
 
     [DoesNotReturn]
-    public static void ThrowValueNotDefined(string value, string? paramName)
+    public static void ThrowValueNotDefined(ReadOnlySpan<char> value, string? paramName)
     {
         var message = $"Specified value '{value}' is not defined.";
         throw new ArgumentException(message, paramName);

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
@@ -90,7 +90,7 @@ internal static class UnderlyingOperation<T>
 
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool TryParseValue(string text, out T result)
+    public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
     {
         switch (EnumInfo<T>.s_typeCode)
         {
@@ -196,7 +196,7 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParseValue(string text, out T result)
+        public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, sbyte>(ref result);
@@ -297,7 +297,7 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParseValue(string text, out T result)
+        public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, byte>(ref result);
@@ -398,7 +398,7 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParseValue(string text, out T result)
+        public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, short>(ref result);
@@ -499,7 +499,7 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParseValue(string text, out T result)
+        public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, ushort>(ref result);
@@ -600,7 +600,7 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParseValue(string text, out T result)
+        public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, int>(ref result);
@@ -701,7 +701,7 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParseValue(string text, out T result)
+        public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, uint>(ref result);
@@ -802,7 +802,7 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParseValue(string text, out T result)
+        public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, long>(ref result);
@@ -903,7 +903,7 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParseValue(string text, out T result)
+        public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, ulong>(ref result);

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
@@ -79,7 +79,7 @@ internal static class UnderlyingOperation<T>
 
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool TryParseValue(string text, out T result)
+    public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
     {
         switch (EnumInfo<T>.s_typeCode)
         {
@@ -162,7 +162,7 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParseValue(string text, out T result)
+        public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, <#= x.CompatibleName #>>(ref result);


### PR DESCRIPTION
# Summary
We will modify the argument type of the following method from `string` to `ReadOnlySpan<char>`. This change will enable users to utilize the API more efficiently.

- `bool IsDefined<T>(ReadOnlySpan<char> value)`
- `T Parse<T>(ReadOnlySpan<char> value)`
- `T Parse<T>(ReadOnlySpan<char> value, bool ignoreCase)`
- `bool TryParse<T>(ReadOnlySpan<char> value, out T result)`
- `bool TryParse<T>(ReadOnlySpan<char> value, bool ignoreCase, out T result)`

This PR fixes #9.