### PR TITLE
Use indexer without range check

### DIFF
--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -238,7 +238,7 @@ public static class FastEnum
             return false;
         }
 
-        if (isNumeric(value[0]))
+        if (isNumeric(value.At(0)))
             return UnderlyingOperation<T>.TryParseValue(value, out result);
 
         if (ignoreCase)

--- a/src/libs/FastEnum.Core/Internals/ArrayExtensions.cs
+++ b/src/libs/FastEnum.Core/Internals/ArrayExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace FastEnumUtility.Internals;
@@ -7,6 +8,17 @@ namespace FastEnumUtility.Internals;
 
 internal static class ArrayExtensions
 {
+    public static ref T At<T>(this ReadOnlySpan<T> span, int index)
+    {
+        // note:
+        //  - `Span[i]` includes a range check, but using `Unsafe` eliminates it.
+        //  - While this increases the risk, it is expected to speed up the process.
+
+        ref var pointer = ref MemoryMarshal.GetReference(span);
+        return ref Unsafe.Add(ref pointer, index);
+    }
+
+
     public static ref T At<T>(this T[] array, int index)
     {
         // note:

--- a/src/libs/FastEnum.Core/Internals/ArrayExtensions.cs
+++ b/src/libs/FastEnum.Core/Internals/ArrayExtensions.cs
@@ -8,6 +8,7 @@ namespace FastEnumUtility.Internals;
 
 internal static class ArrayExtensions
 {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T At<T>(this ReadOnlySpan<T> span, int index)
     {
         // note:
@@ -19,6 +20,7 @@ internal static class ArrayExtensions
     }
 
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T At<T>(this T[] array, int index)
     {
         // note:

--- a/src/libs/FastEnum.Core/Internals/ArrayExtensions.cs
+++ b/src/libs/FastEnum.Core/Internals/ArrayExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace FastEnumUtility.Internals;
+
+
+
+internal static class ArrayExtensions
+{
+    public static ref T At<T>(this T[] array, int index)
+    {
+        // note:
+        //  - `Array[i]` includes a range check, but using `Unsafe` eliminates it.
+        //  - While this increases the risk, it is expected to speed up the process.
+
+        ref var pointer = ref MemoryMarshal.GetArrayDataReference(array);
+        return ref Unsafe.Add(ref pointer, index);
+    }
+}

--- a/src/libs/FastEnum.Core/Internals/SpecializedDictionary.cs
+++ b/src/libs/FastEnum.Core/Internals/SpecializedDictionary.cs
@@ -84,11 +84,11 @@ internal sealed class FastReadOnlyDictionary<TKey, TValue>
         {
             var hash = s_comparer.GetHashCode(entry.Key);
             var index = hash & indexFor;
-            var target = buckets[index];
+            var target = buckets.At(index);
             if (target is null)
             {
                 //--- Add new entry
-                buckets[index] = entry;
+                buckets.At(index) = entry;
                 return true;
             }
 
@@ -128,7 +128,7 @@ internal sealed class FastReadOnlyDictionary<TKey, TValue>
     {
         var hash = s_comparer.GetHashCode(key);
         var index = hash & this._indexFor;
-        var entry = this._buckets[index];
+        var entry = this._buckets.At(index);
         while (entry is not null)
         {
             if (s_comparer.Equals(entry.Key, key))
@@ -224,11 +224,11 @@ internal sealed class CaseSensitiveStringDictionary<TValue>
         {
             var hash = CaseSensitiveStringHelpers.GetHashCode(entry.Key);
             var index = hash & indexFor;
-            var target = buckets[index];
+            var target = buckets.At(index);
             if (target is null)
             {
                 //--- Add new entry
-                buckets[index] = entry;
+                buckets.At(index) = entry;
                 return true;
             }
 
@@ -268,7 +268,7 @@ internal sealed class CaseSensitiveStringDictionary<TValue>
     {
         var hash = CaseSensitiveStringHelpers.GetHashCode(key);
         var index = hash & this._indexFor;
-        var entry = this._buckets[index];
+        var entry = this._buckets.At(index);
         while (entry is not null)
         {
             if (CaseSensitiveStringHelpers.Equals(key, entry.Key))
@@ -364,11 +364,11 @@ internal sealed class CaseInsensitiveStringDictionary<TValue>
         {
             var hash = CaseInsensitiveStringHelpers.GetHashCode(entry.Key);
             var index = hash & indexFor;
-            var target = buckets[index];
+            var target = buckets.At(index);
             if (target is null)
             {
                 //--- Add new entry
-                buckets[index] = entry;
+                buckets.At(index) = entry;
                 return true;
             }
 
@@ -408,7 +408,7 @@ internal sealed class CaseInsensitiveStringDictionary<TValue>
     {
         var hash = CaseInsensitiveStringHelpers.GetHashCode(key);
         var index = hash & this._indexFor;
-        var entry = this._buckets[index];
+        var entry = this._buckets.At(index);
         while (entry is not null)
         {
             if (CaseInsensitiveStringHelpers.Equals(entry.Key, key))

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
@@ -215,11 +215,11 @@ internal static class UnderlyingOperation<T>
             {
                 var val = toNumber(value);
                 var min = toNumber(EnumInfo<T>.s_minValue);
-                var index = val - min;
+                var index = (int)(val - min);
                 var members = EnumInfo<T>.s_orderedMembers;
                 if ((uint)index < (uint)members.Length)
                 {
-                    result = members[index];
+                    result = members.At(index);
                     return true;
                 }
                 else
@@ -316,11 +316,11 @@ internal static class UnderlyingOperation<T>
             {
                 var val = toNumber(value);
                 var min = toNumber(EnumInfo<T>.s_minValue);
-                var index = val - min;
+                var index = (int)(val - min);
                 var members = EnumInfo<T>.s_orderedMembers;
                 if ((uint)index < (uint)members.Length)
                 {
-                    result = members[index];
+                    result = members.At(index);
                     return true;
                 }
                 else
@@ -417,11 +417,11 @@ internal static class UnderlyingOperation<T>
             {
                 var val = toNumber(value);
                 var min = toNumber(EnumInfo<T>.s_minValue);
-                var index = val - min;
+                var index = (int)(val - min);
                 var members = EnumInfo<T>.s_orderedMembers;
                 if ((uint)index < (uint)members.Length)
                 {
-                    result = members[index];
+                    result = members.At(index);
                     return true;
                 }
                 else
@@ -518,11 +518,11 @@ internal static class UnderlyingOperation<T>
             {
                 var val = toNumber(value);
                 var min = toNumber(EnumInfo<T>.s_minValue);
-                var index = val - min;
+                var index = (int)(val - min);
                 var members = EnumInfo<T>.s_orderedMembers;
                 if ((uint)index < (uint)members.Length)
                 {
-                    result = members[index];
+                    result = members.At(index);
                     return true;
                 }
                 else
@@ -619,11 +619,11 @@ internal static class UnderlyingOperation<T>
             {
                 var val = toNumber(value);
                 var min = toNumber(EnumInfo<T>.s_minValue);
-                var index = val - min;
+                var index = (int)(val - min);
                 var members = EnumInfo<T>.s_orderedMembers;
                 if ((uint)index < (uint)members.Length)
                 {
-                    result = members[index];
+                    result = members.At(index);
                     return true;
                 }
                 else
@@ -720,11 +720,11 @@ internal static class UnderlyingOperation<T>
             {
                 var val = toNumber(value);
                 var min = toNumber(EnumInfo<T>.s_minValue);
-                var index = val - min;
+                var index = (int)(val - min);
                 var members = EnumInfo<T>.s_orderedMembers;
                 if ((uint)index < (uint)members.Length)
                 {
-                    result = members[index];
+                    result = members.At(index);
                     return true;
                 }
                 else
@@ -821,11 +821,11 @@ internal static class UnderlyingOperation<T>
             {
                 var val = toNumber(value);
                 var min = toNumber(EnumInfo<T>.s_minValue);
-                var index = val - min;
+                var index = (int)(val - min);
                 var members = EnumInfo<T>.s_orderedMembers;
                 if ((uint)index < (uint)members.Length)
                 {
-                    result = members[index];
+                    result = members.At(index);
                     return true;
                 }
                 else
@@ -922,11 +922,11 @@ internal static class UnderlyingOperation<T>
             {
                 var val = toNumber(value);
                 var min = toNumber(EnumInfo<T>.s_minValue);
-                var index = val - min;
+                var index = (int)(val - min);
                 var members = EnumInfo<T>.s_orderedMembers;
                 if ((uint)index < (uint)members.Length)
                 {
-                    result = members[index];
+                    result = members.At(index);
                     return true;
                 }
                 else

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
@@ -181,11 +181,11 @@ internal static class UnderlyingOperation<T>
             {
                 var val = toNumber(value);
                 var min = toNumber(EnumInfo<T>.s_minValue);
-                var index = val - min;
+                var index = (int)(val - min);
                 var members = EnumInfo<T>.s_orderedMembers;
                 if ((uint)index < (uint)members.Length)
                 {
-                    result = members[index];
+                    result = members.At(index);
                     return true;
                 }
                 else


### PR DESCRIPTION
# Summary
`Array[i]` includes a range check, but using `Unsafe` eliminates it. While this increases the risk, it is expected to speed up the process.
