### PR TITLE
Should support ASCII digit only

### DIFF
--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -250,7 +250,7 @@ public static class FastEnum
         #region Local Functions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool isNumeric(char c)
-            => char.IsDigit(c) || (c is '-' or '+');
+            => char.IsAsciiDigit(c) || (c is '-' or '+');
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
# Summary
`System.Enum` only parses digits contained in ASCII codes, so this library is followed.