### PR TITLE
Support UTF-8 byte sequence

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,5 +10,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="MSTest" Version="3.5.2" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/insights/FastEnum.Benchmarks/Program.cs
+++ b/src/insights/FastEnum.Benchmarks/Program.cs
@@ -16,7 +16,7 @@ var switcher = new BenchmarkSwitcher(
     typeof(IsDefined_String),
     typeof(ToString_Defined),
     typeof(ToString_Undefined),
-    typeof(TryParse_CaseInsensitive),
-    typeof(TryParse_CaseSensitive),
+    typeof(TryParse_Char_CaseInsensitive),
+    typeof(TryParse_Char_CaseSensitive),
 ]);
 switcher.Run(args, config);

--- a/src/insights/FastEnum.Benchmarks/Program.cs
+++ b/src/insights/FastEnum.Benchmarks/Program.cs
@@ -16,6 +16,7 @@ var switcher = new BenchmarkSwitcher(
     typeof(IsDefined_String),
     typeof(ToString_Defined),
     typeof(ToString_Undefined),
+    typeof(TryParse_Byte_CaseSensitive),
     typeof(TryParse_Char_CaseInsensitive),
     typeof(TryParse_Char_CaseSensitive),
 ]);

--- a/src/insights/FastEnum.Benchmarks/Scenarios/TryParse_Byte_CaseSensitive.cs
+++ b/src/insights/FastEnum.Benchmarks/Scenarios/TryParse_Byte_CaseSensitive.cs
@@ -1,0 +1,39 @@
+﻿extern alias FastEnumV1;
+
+using System;
+using BenchmarkDotNet.Attributes;
+using FastEnumUtility.Benchmarks.Models;
+using FastEnum2 = FastEnumUtility.FastEnum;
+
+namespace FastEnumUtility.Benchmarks.Scenarios;
+
+
+
+public class TryParse_Byte_CaseSensitive
+{
+    private const string Text = nameof(Fruits.Apple);
+    private static readonly byte[] Bytes = [(byte)'A', (byte)'p', (byte)'p', (byte)'l', (byte)'e'];
+
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _ = Enum.GetNames<Fruits>();
+        _ = FastEnum2.GetMembers<Fruits>();
+    }
+
+
+    [Benchmark(Baseline = true)]
+    public bool NetCore()
+        => Enum.TryParse<Fruits>(Text, out _);
+
+
+    [Benchmark]
+    public bool FastEnum_v2_String()
+        => FastEnum2.TryParse<Fruits>(Text, out _);
+
+
+    [Benchmark]
+    public bool FastEnum_v2_Byte()
+        => FastEnum2.TryParse<Fruits>(Bytes, out _);
+}

--- a/src/insights/FastEnum.Benchmarks/Scenarios/TryParse_Char_CaseInsensitive.cs
+++ b/src/insights/FastEnum.Benchmarks/Scenarios/TryParse_Char_CaseInsensitive.cs
@@ -11,7 +11,7 @@ namespace FastEnumUtility.Benchmarks.Scenarios;
 
 
 
-public class TryParse_CaseInsensitive
+public class TryParse_Char_CaseInsensitive
 {
     private const string Value = nameof(Fruits.WaterMelon);
 

--- a/src/insights/FastEnum.Benchmarks/Scenarios/TryParse_Char_CaseSensitive.cs
+++ b/src/insights/FastEnum.Benchmarks/Scenarios/TryParse_Char_CaseSensitive.cs
@@ -11,7 +11,7 @@ namespace FastEnumUtility.Benchmarks.Scenarios;
 
 
 
-public class TryParse_CaseSensitive
+public class TryParse_Char_CaseSensitive
 {
     private const string Value = nameof(Fruits.WaterMelon);
 

--- a/src/insights/FastEnum.UnitTests/Cases/BasicTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/BasicTests.cs
@@ -173,20 +173,30 @@ public sealed class SByteTests
     [TestMethod]
     public void IsDefined()
     {
+        //--- IsDefined(TEnum)
         FastEnum.IsDefined<SByteEnum>(SByteEnum.MinValue).Should().BeTrue();
         FastEnum.IsDefined<SByteEnum>(SByteEnum.Zero).Should().BeTrue();
         FastEnum.IsDefined<SByteEnum>(SByteEnum.MaxValue).Should().BeTrue();
         FastEnum.IsDefined<SByteEnum>((SByteEnum)123).Should().BeFalse();
 
+        //--- Extension methods
         SByteEnum.MinValue.IsDefined().Should().BeTrue();
         SByteEnum.Zero.IsDefined().Should().BeTrue();
         SByteEnum.MaxValue.IsDefined().Should().BeTrue();
 
+        //--- IsDefined(ReadOnlySpan<char>)
         FastEnum.IsDefined<SByteEnum>(nameof(SByteEnum.MinValue)).Should().BeTrue();
         FastEnum.IsDefined<SByteEnum>(nameof(SByteEnum.Zero)).Should().BeTrue();
         FastEnum.IsDefined<SByteEnum>(nameof(SByteEnum.MaxValue)).Should().BeTrue();
         FastEnum.IsDefined<SByteEnum>("123").Should().BeFalse();
         FastEnum.IsDefined<SByteEnum>("minvalue").Should().BeFalse();
+
+        //--- IsDefined(ReadOnlySpan<byte>)
+        FastEnum.IsDefined<SByteEnum>("MinValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<SByteEnum>("Zero"u8).Should().BeTrue();
+        FastEnum.IsDefined<SByteEnum>("MaxValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<SByteEnum>("123"u8).Should().BeFalse();
+        FastEnum.IsDefined<SByteEnum>("minvalue"u8).Should().BeFalse();
     }
 
 
@@ -520,17 +530,26 @@ public sealed class ByteTests
     [TestMethod]
     public void IsDefined()
     {
+        //--- IsDefined(TEnum)
         FastEnum.IsDefined<ByteEnum>(ByteEnum.MinValue).Should().BeTrue();
         FastEnum.IsDefined<ByteEnum>(ByteEnum.MaxValue).Should().BeTrue();
         FastEnum.IsDefined<ByteEnum>((ByteEnum)123).Should().BeFalse();
 
+        //--- Extension methods
         ByteEnum.MinValue.IsDefined().Should().BeTrue();
         ByteEnum.MaxValue.IsDefined().Should().BeTrue();
 
+        //--- IsDefined(ReadOnlySpan<char>)
         FastEnum.IsDefined<ByteEnum>(nameof(ByteEnum.MinValue)).Should().BeTrue();
         FastEnum.IsDefined<ByteEnum>(nameof(ByteEnum.MaxValue)).Should().BeTrue();
         FastEnum.IsDefined<ByteEnum>("123").Should().BeFalse();
         FastEnum.IsDefined<ByteEnum>("minvalue").Should().BeFalse();
+
+        //--- IsDefined(ReadOnlySpan<byte>)
+        FastEnum.IsDefined<ByteEnum>("MinValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<ByteEnum>("MaxValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<ByteEnum>("123"u8).Should().BeFalse();
+        FastEnum.IsDefined<ByteEnum>("minvalue"u8).Should().BeFalse();
     }
 
 
@@ -859,20 +878,30 @@ public sealed class Int16Tests
     [TestMethod]
     public void IsDefined()
     {
+        //--- IsDefined(TEnum)
         FastEnum.IsDefined<Int16Enum>(Int16Enum.MinValue).Should().BeTrue();
         FastEnum.IsDefined<Int16Enum>(Int16Enum.Zero).Should().BeTrue();
         FastEnum.IsDefined<Int16Enum>(Int16Enum.MaxValue).Should().BeTrue();
         FastEnum.IsDefined<Int16Enum>((Int16Enum)123).Should().BeFalse();
 
+        //--- Extension methods
         Int16Enum.MinValue.IsDefined().Should().BeTrue();
         Int16Enum.Zero.IsDefined().Should().BeTrue();
         Int16Enum.MaxValue.IsDefined().Should().BeTrue();
 
+        //--- IsDefined(ReadOnlySpan<char>)
         FastEnum.IsDefined<Int16Enum>(nameof(Int16Enum.MinValue)).Should().BeTrue();
         FastEnum.IsDefined<Int16Enum>(nameof(Int16Enum.Zero)).Should().BeTrue();
         FastEnum.IsDefined<Int16Enum>(nameof(Int16Enum.MaxValue)).Should().BeTrue();
         FastEnum.IsDefined<Int16Enum>("123").Should().BeFalse();
         FastEnum.IsDefined<Int16Enum>("minvalue").Should().BeFalse();
+
+        //--- IsDefined(ReadOnlySpan<byte>)
+        FastEnum.IsDefined<Int16Enum>("MinValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<Int16Enum>("Zero"u8).Should().BeTrue();
+        FastEnum.IsDefined<Int16Enum>("MaxValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<Int16Enum>("123"u8).Should().BeFalse();
+        FastEnum.IsDefined<Int16Enum>("minvalue"u8).Should().BeFalse();
     }
 
 
@@ -1206,17 +1235,26 @@ public sealed class UInt16Tests
     [TestMethod]
     public void IsDefined()
     {
+        //--- IsDefined(TEnum)
         FastEnum.IsDefined<UInt16Enum>(UInt16Enum.MinValue).Should().BeTrue();
         FastEnum.IsDefined<UInt16Enum>(UInt16Enum.MaxValue).Should().BeTrue();
         FastEnum.IsDefined<UInt16Enum>((UInt16Enum)123).Should().BeFalse();
 
+        //--- Extension methods
         UInt16Enum.MinValue.IsDefined().Should().BeTrue();
         UInt16Enum.MaxValue.IsDefined().Should().BeTrue();
 
+        //--- IsDefined(ReadOnlySpan<char>)
         FastEnum.IsDefined<UInt16Enum>(nameof(UInt16Enum.MinValue)).Should().BeTrue();
         FastEnum.IsDefined<UInt16Enum>(nameof(UInt16Enum.MaxValue)).Should().BeTrue();
         FastEnum.IsDefined<UInt16Enum>("123").Should().BeFalse();
         FastEnum.IsDefined<UInt16Enum>("minvalue").Should().BeFalse();
+
+        //--- IsDefined(ReadOnlySpan<byte>)
+        FastEnum.IsDefined<UInt16Enum>("MinValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<UInt16Enum>("MaxValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<UInt16Enum>("123"u8).Should().BeFalse();
+        FastEnum.IsDefined<UInt16Enum>("minvalue"u8).Should().BeFalse();
     }
 
 
@@ -1545,20 +1583,30 @@ public sealed class Int32Tests
     [TestMethod]
     public void IsDefined()
     {
+        //--- IsDefined(TEnum)
         FastEnum.IsDefined<Int32Enum>(Int32Enum.MinValue).Should().BeTrue();
         FastEnum.IsDefined<Int32Enum>(Int32Enum.Zero).Should().BeTrue();
         FastEnum.IsDefined<Int32Enum>(Int32Enum.MaxValue).Should().BeTrue();
         FastEnum.IsDefined<Int32Enum>((Int32Enum)123).Should().BeFalse();
 
+        //--- Extension methods
         Int32Enum.MinValue.IsDefined().Should().BeTrue();
         Int32Enum.Zero.IsDefined().Should().BeTrue();
         Int32Enum.MaxValue.IsDefined().Should().BeTrue();
 
+        //--- IsDefined(ReadOnlySpan<char>)
         FastEnum.IsDefined<Int32Enum>(nameof(Int32Enum.MinValue)).Should().BeTrue();
         FastEnum.IsDefined<Int32Enum>(nameof(Int32Enum.Zero)).Should().BeTrue();
         FastEnum.IsDefined<Int32Enum>(nameof(Int32Enum.MaxValue)).Should().BeTrue();
         FastEnum.IsDefined<Int32Enum>("123").Should().BeFalse();
         FastEnum.IsDefined<Int32Enum>("minvalue").Should().BeFalse();
+
+        //--- IsDefined(ReadOnlySpan<byte>)
+        FastEnum.IsDefined<Int32Enum>("MinValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<Int32Enum>("Zero"u8).Should().BeTrue();
+        FastEnum.IsDefined<Int32Enum>("MaxValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<Int32Enum>("123"u8).Should().BeFalse();
+        FastEnum.IsDefined<Int32Enum>("minvalue"u8).Should().BeFalse();
     }
 
 
@@ -1892,17 +1940,26 @@ public sealed class UInt32Tests
     [TestMethod]
     public void IsDefined()
     {
+        //--- IsDefined(TEnum)
         FastEnum.IsDefined<UInt32Enum>(UInt32Enum.MinValue).Should().BeTrue();
         FastEnum.IsDefined<UInt32Enum>(UInt32Enum.MaxValue).Should().BeTrue();
         FastEnum.IsDefined<UInt32Enum>((UInt32Enum)123).Should().BeFalse();
 
+        //--- Extension methods
         UInt32Enum.MinValue.IsDefined().Should().BeTrue();
         UInt32Enum.MaxValue.IsDefined().Should().BeTrue();
 
+        //--- IsDefined(ReadOnlySpan<char>)
         FastEnum.IsDefined<UInt32Enum>(nameof(UInt32Enum.MinValue)).Should().BeTrue();
         FastEnum.IsDefined<UInt32Enum>(nameof(UInt32Enum.MaxValue)).Should().BeTrue();
         FastEnum.IsDefined<UInt32Enum>("123").Should().BeFalse();
         FastEnum.IsDefined<UInt32Enum>("minvalue").Should().BeFalse();
+
+        //--- IsDefined(ReadOnlySpan<byte>)
+        FastEnum.IsDefined<UInt32Enum>("MinValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<UInt32Enum>("MaxValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<UInt32Enum>("123"u8).Should().BeFalse();
+        FastEnum.IsDefined<UInt32Enum>("minvalue"u8).Should().BeFalse();
     }
 
 
@@ -2231,20 +2288,30 @@ public sealed class Int64Tests
     [TestMethod]
     public void IsDefined()
     {
+        //--- IsDefined(TEnum)
         FastEnum.IsDefined<Int64Enum>(Int64Enum.MinValue).Should().BeTrue();
         FastEnum.IsDefined<Int64Enum>(Int64Enum.Zero).Should().BeTrue();
         FastEnum.IsDefined<Int64Enum>(Int64Enum.MaxValue).Should().BeTrue();
         FastEnum.IsDefined<Int64Enum>((Int64Enum)123).Should().BeFalse();
 
+        //--- Extension methods
         Int64Enum.MinValue.IsDefined().Should().BeTrue();
         Int64Enum.Zero.IsDefined().Should().BeTrue();
         Int64Enum.MaxValue.IsDefined().Should().BeTrue();
 
+        //--- IsDefined(ReadOnlySpan<char>)
         FastEnum.IsDefined<Int64Enum>(nameof(Int64Enum.MinValue)).Should().BeTrue();
         FastEnum.IsDefined<Int64Enum>(nameof(Int64Enum.Zero)).Should().BeTrue();
         FastEnum.IsDefined<Int64Enum>(nameof(Int64Enum.MaxValue)).Should().BeTrue();
         FastEnum.IsDefined<Int64Enum>("123").Should().BeFalse();
         FastEnum.IsDefined<Int64Enum>("minvalue").Should().BeFalse();
+
+        //--- IsDefined(ReadOnlySpan<byte>)
+        FastEnum.IsDefined<Int64Enum>("MinValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<Int64Enum>("Zero"u8).Should().BeTrue();
+        FastEnum.IsDefined<Int64Enum>("MaxValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<Int64Enum>("123"u8).Should().BeFalse();
+        FastEnum.IsDefined<Int64Enum>("minvalue"u8).Should().BeFalse();
     }
 
 
@@ -2578,17 +2645,26 @@ public sealed class UInt64Tests
     [TestMethod]
     public void IsDefined()
     {
+        //--- IsDefined(TEnum)
         FastEnum.IsDefined<UInt64Enum>(UInt64Enum.MinValue).Should().BeTrue();
         FastEnum.IsDefined<UInt64Enum>(UInt64Enum.MaxValue).Should().BeTrue();
         FastEnum.IsDefined<UInt64Enum>((UInt64Enum)123).Should().BeFalse();
 
+        //--- Extension methods
         UInt64Enum.MinValue.IsDefined().Should().BeTrue();
         UInt64Enum.MaxValue.IsDefined().Should().BeTrue();
 
+        //--- IsDefined(ReadOnlySpan<char>)
         FastEnum.IsDefined<UInt64Enum>(nameof(UInt64Enum.MinValue)).Should().BeTrue();
         FastEnum.IsDefined<UInt64Enum>(nameof(UInt64Enum.MaxValue)).Should().BeTrue();
         FastEnum.IsDefined<UInt64Enum>("123").Should().BeFalse();
         FastEnum.IsDefined<UInt64Enum>("minvalue").Should().BeFalse();
+
+        //--- IsDefined(ReadOnlySpan<byte>)
+        FastEnum.IsDefined<UInt64Enum>("MinValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<UInt64Enum>("MaxValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<UInt64Enum>("123"u8).Should().BeFalse();
+        FastEnum.IsDefined<UInt64Enum>("minvalue"u8).Should().BeFalse();
     }
 
 

--- a/src/insights/FastEnum.UnitTests/Cases/BasicTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/BasicTests.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -205,22 +206,53 @@ public sealed class SByteTests
     {
         var parameters = new[]
         {
-            (value: SByteEnum.MinValue, name: nameof(SByteEnum.MinValue), valueString: ((sbyte)SByteEnum.MinValue).ToString()),
-            (value: SByteEnum.Zero,     name: nameof(SByteEnum.Zero),     valueString: ((sbyte)SByteEnum.Zero).ToString()),
-            (value: SByteEnum.MaxValue, name: nameof(SByteEnum.MaxValue), valueString: ((sbyte)SByteEnum.MaxValue).ToString()),
+            (value: SByteEnum.MinValue, name: nameof(SByteEnum.MinValue), valueString: ((sbyte)SByteEnum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: SByteEnum.Zero,     name: nameof(SByteEnum.Zero),     valueString: ((sbyte)SByteEnum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: SByteEnum.MaxValue, name: nameof(SByteEnum.MaxValue), valueString: ((sbyte)SByteEnum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.Parse<SByteEnum>(x.name).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<SByteEnum>(x.name.ToLower())).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<SByteEnum>(x.name.ToUpper())).Should().Throw<ArgumentException>();
-            FastEnum.Parse<SByteEnum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(x.valueString.ToLower()).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(x.valueString.ToUpper()).Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.Parse<SByteEnum>(x.name).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FastEnum.Parse<SByteEnum>(x.valueString).Should().Be(x.value);
+                FastEnum.Parse<SByteEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
+                FastEnum.Parse<SByteEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>((string?)null, true)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<SByteEnum>("123").Should().Be((SByteEnum)123);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("ABCDE")).Should().Throw<ArgumentException>();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.Parse<SByteEnum>(nameUtf8).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<SByteEnum>(nameUtf8Lower)).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<SByteEnum>(nameUtf8Upper)).Should().Throw<ArgumentException>();
+                FastEnum.Parse<SByteEnum>(valueUtf8).Should().Be(x.value);
+                FastEnum.Parse<SByteEnum>(valueUtf8Lower).Should().Be(x.value);
+                FastEnum.Parse<SByteEnum>(valueUtf8Upper).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<SByteEnum>("123"u8).Should().Be((SByteEnum)123);
+        }
     }
 
 
@@ -229,22 +261,24 @@ public sealed class SByteTests
     {
         var parameters = new[]
         {
-            (value: SByteEnum.MinValue, name: nameof(SByteEnum.MinValue), valueString: ((sbyte)SByteEnum.MinValue).ToString()),
-            (value: SByteEnum.Zero,     name: nameof(SByteEnum.Zero),     valueString: ((sbyte)SByteEnum.Zero).ToString()),
-            (value: SByteEnum.MaxValue, name: nameof(SByteEnum.MaxValue), valueString: ((sbyte)SByteEnum.MaxValue).ToString()),
+            (value: SByteEnum.MinValue, name: nameof(SByteEnum.MinValue), valueString: ((sbyte)SByteEnum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: SByteEnum.Zero,     name: nameof(SByteEnum.Zero),     valueString: ((sbyte)SByteEnum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: SByteEnum.MaxValue, name: nameof(SByteEnum.MaxValue), valueString: ((sbyte)SByteEnum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.Parse<SByteEnum>(x.name, true).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(x.name.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(x.name.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<SByteEnum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(x.valueString.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(x.valueString.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<SByteEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<SByteEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>((string?)null, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<SByteEnum>("123").Should().Be((SByteEnum)123);
     }
 
 
@@ -253,29 +287,71 @@ public sealed class SByteTests
     {
         var parameters = new[]
         {
-            (value: SByteEnum.MinValue, name: nameof(SByteEnum.MinValue), valueString: ((sbyte)SByteEnum.MinValue).ToString()),
-            (value: SByteEnum.Zero,     name: nameof(SByteEnum.Zero),     valueString: ((sbyte)SByteEnum.Zero).ToString()),
-            (value: SByteEnum.MaxValue, name: nameof(SByteEnum.MaxValue), valueString: ((sbyte)SByteEnum.MaxValue).ToString()),
+            (value: SByteEnum.MinValue, name: nameof(SByteEnum.MinValue), valueString: ((sbyte)SByteEnum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: SByteEnum.Zero,     name: nameof(SByteEnum.Zero),     valueString: ((sbyte)SByteEnum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: SByteEnum.MaxValue, name: nameof(SByteEnum.MaxValue), valueString: ((sbyte)SByteEnum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.TryParse<SByteEnum>(x.name, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.TryParse<SByteEnum>(x.name, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
 
-            FastEnum.TryParse<SByteEnum>(x.name.ToLower(), out var _).Should().BeFalse();
-            FastEnum.TryParse<SByteEnum>(x.name.ToUpper(), out var _).Should().BeFalse();
+                FastEnum.TryParse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
 
-            FastEnum.TryParse<SByteEnum>(x.valueString, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+                FastEnum.TryParse<SByteEnum>(x.valueString, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
 
-            FastEnum.TryParse<SByteEnum>(x.valueString.ToLower(), out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+                FastEnum.TryParse<SByteEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
 
-            FastEnum.TryParse<SByteEnum>(x.valueString.ToUpper(), out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+                FastEnum.TryParse<SByteEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<SByteEnum>((string?)null, out var _).Should().BeFalse();
+            FastEnum.TryParse<SByteEnum>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<SByteEnum>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<SByteEnum>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<SByteEnum>("123", out var r).Should().BeTrue();
+            r.Should().Be((SByteEnum)123);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<SByteEnum>(x, out var _).Should().BeFalse();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.TryParse<SByteEnum>(nameUtf8, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
+
+                FastEnum.TryParse<SByteEnum>(nameUtf8Lower, out var _).Should().BeFalse();
+                FastEnum.TryParse<SByteEnum>(nameUtf8Upper, out var _).Should().BeFalse();
+
+                FastEnum.TryParse<SByteEnum>(valueUtf8, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
+
+                FastEnum.TryParse<SByteEnum>(valueUtf8Lower, out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
+
+                FastEnum.TryParse<SByteEnum>(valueUtf8Upper, out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<SByteEnum>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<SByteEnum>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<SByteEnum>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<SByteEnum>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((SByteEnum)123);
+        }
     }
 
 
@@ -284,32 +360,36 @@ public sealed class SByteTests
     {
         var parameters = new[]
         {
-            (value: SByteEnum.MinValue, name: nameof(SByteEnum.MinValue), valueString: ((sbyte)SByteEnum.MinValue).ToString()),
-            (value: SByteEnum.Zero,     name: nameof(SByteEnum.Zero),     valueString: ((sbyte)SByteEnum.Zero).ToString()),
-            (value: SByteEnum.MaxValue, name: nameof(SByteEnum.MaxValue), valueString: ((sbyte)SByteEnum.MaxValue).ToString()),
+            (value: SByteEnum.MinValue, name: nameof(SByteEnum.MinValue), valueString: ((sbyte)SByteEnum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: SByteEnum.Zero,     name: nameof(SByteEnum.Zero),     valueString: ((sbyte)SByteEnum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: SByteEnum.MaxValue, name: nameof(SByteEnum.MaxValue), valueString: ((sbyte)SByteEnum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.TryParse<SByteEnum>(x.name, true, out var r1).Should().BeTrue();
             r1.Should().Be(x.value);
 
-            FastEnum.TryParse<SByteEnum>(x.name.ToLower(), true, out var r2).Should().BeTrue();
+            FastEnum.TryParse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), true, out var r2).Should().BeTrue();
             r2.Should().Be(x.value);
 
-            FastEnum.TryParse<SByteEnum>(x.name.ToUpper(), true, out var r3).Should().BeTrue();
+            FastEnum.TryParse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), true, out var r3).Should().BeTrue();
             r3.Should().Be(x.value);
 
             FastEnum.TryParse<SByteEnum>(x.valueString, true, out var r4).Should().BeTrue();
             r4.Should().Be(x.value);
 
-            FastEnum.TryParse<SByteEnum>(x.valueString.ToLower(), true, out var r5).Should().BeTrue();
+            FastEnum.TryParse<SByteEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true, out var r5).Should().BeTrue();
             r5.Should().Be(x.value);
 
-            FastEnum.TryParse<SByteEnum>(x.valueString.ToUpper(), true, out var r6).Should().BeTrue();
+            FastEnum.TryParse<SByteEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true, out var r6).Should().BeTrue();
             r6.Should().Be(x.value);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<SByteEnum>(x, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<SByteEnum>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<SByteEnum>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<SByteEnum>(" ", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<SByteEnum>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<SByteEnum>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((SByteEnum)123);
     }
 
 
@@ -558,21 +638,52 @@ public sealed class ByteTests
     {
         var parameters = new[]
         {
-            (value: ByteEnum.MinValue, name: nameof(ByteEnum.MinValue), valueString: ((byte)ByteEnum.MinValue).ToString()),
-            (value: ByteEnum.MaxValue, name: nameof(ByteEnum.MaxValue), valueString: ((byte)ByteEnum.MaxValue).ToString()),
+            (value: ByteEnum.MinValue, name: nameof(ByteEnum.MinValue), valueString: ((byte)ByteEnum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: ByteEnum.MaxValue, name: nameof(ByteEnum.MaxValue), valueString: ((byte)ByteEnum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.Parse<ByteEnum>(x.name).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ByteEnum>(x.name.ToLower())).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<ByteEnum>(x.name.ToUpper())).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ByteEnum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(x.valueString.ToLower()).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(x.valueString.ToUpper()).Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.Parse<ByteEnum>(x.name).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FastEnum.Parse<ByteEnum>(x.valueString).Should().Be(x.value);
+                FastEnum.Parse<ByteEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
+                FastEnum.Parse<ByteEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>((string?)null, true)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<ByteEnum>("123").Should().Be((ByteEnum)123);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("ABCDE")).Should().Throw<ArgumentException>();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.Parse<ByteEnum>(nameUtf8).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<ByteEnum>(nameUtf8Lower)).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<ByteEnum>(nameUtf8Upper)).Should().Throw<ArgumentException>();
+                FastEnum.Parse<ByteEnum>(valueUtf8).Should().Be(x.value);
+                FastEnum.Parse<ByteEnum>(valueUtf8Lower).Should().Be(x.value);
+                FastEnum.Parse<ByteEnum>(valueUtf8Upper).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<ByteEnum>("123"u8).Should().Be((ByteEnum)123);
+        }
     }
 
 
@@ -581,21 +692,23 @@ public sealed class ByteTests
     {
         var parameters = new[]
         {
-            (value: ByteEnum.MinValue, name: nameof(ByteEnum.MinValue), valueString: ((byte)ByteEnum.MinValue).ToString()),
-            (value: ByteEnum.MaxValue, name: nameof(ByteEnum.MaxValue), valueString: ((byte)ByteEnum.MaxValue).ToString()),
+            (value: ByteEnum.MinValue, name: nameof(ByteEnum.MinValue), valueString: ((byte)ByteEnum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: ByteEnum.MaxValue, name: nameof(ByteEnum.MaxValue), valueString: ((byte)ByteEnum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.Parse<ByteEnum>(x.name, true).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(x.name.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(x.name.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<ByteEnum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(x.valueString.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(x.valueString.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<ByteEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<ByteEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>((string?)null, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<ByteEnum>("123").Should().Be((ByteEnum)123);
     }
 
 
@@ -604,28 +717,70 @@ public sealed class ByteTests
     {
         var parameters = new[]
         {
-            (value: ByteEnum.MinValue, name: nameof(ByteEnum.MinValue), valueString: ((byte)ByteEnum.MinValue).ToString()),
-            (value: ByteEnum.MaxValue, name: nameof(ByteEnum.MaxValue), valueString: ((byte)ByteEnum.MaxValue).ToString()),
+            (value: ByteEnum.MinValue, name: nameof(ByteEnum.MinValue), valueString: ((byte)ByteEnum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: ByteEnum.MaxValue, name: nameof(ByteEnum.MaxValue), valueString: ((byte)ByteEnum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.TryParse<ByteEnum>(x.name, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.TryParse<ByteEnum>(x.name, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
 
-            FastEnum.TryParse<ByteEnum>(x.name.ToLower(), out var _).Should().BeFalse();
-            FastEnum.TryParse<ByteEnum>(x.name.ToUpper(), out var _).Should().BeFalse();
+                FastEnum.TryParse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
 
-            FastEnum.TryParse<ByteEnum>(x.valueString, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+                FastEnum.TryParse<ByteEnum>(x.valueString, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
 
-            FastEnum.TryParse<ByteEnum>(x.valueString.ToLower(), out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+                FastEnum.TryParse<ByteEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
 
-            FastEnum.TryParse<ByteEnum>(x.valueString.ToUpper(), out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+                FastEnum.TryParse<ByteEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<ByteEnum>((string?)null, out var _).Should().BeFalse();
+            FastEnum.TryParse<ByteEnum>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<ByteEnum>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<ByteEnum>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<ByteEnum>("123", out var r).Should().BeTrue();
+            r.Should().Be((ByteEnum)123);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<ByteEnum>(x, out var _).Should().BeFalse();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.TryParse<ByteEnum>(nameUtf8, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
+
+                FastEnum.TryParse<ByteEnum>(nameUtf8Lower, out var _).Should().BeFalse();
+                FastEnum.TryParse<ByteEnum>(nameUtf8Upper, out var _).Should().BeFalse();
+
+                FastEnum.TryParse<ByteEnum>(valueUtf8, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
+
+                FastEnum.TryParse<ByteEnum>(valueUtf8Lower, out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
+
+                FastEnum.TryParse<ByteEnum>(valueUtf8Upper, out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<ByteEnum>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<ByteEnum>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<ByteEnum>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<ByteEnum>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((ByteEnum)123);
+        }
     }
 
 
@@ -634,31 +789,35 @@ public sealed class ByteTests
     {
         var parameters = new[]
         {
-            (value: ByteEnum.MinValue, name: nameof(ByteEnum.MinValue), valueString: ((byte)ByteEnum.MinValue).ToString()),
-            (value: ByteEnum.MaxValue, name: nameof(ByteEnum.MaxValue), valueString: ((byte)ByteEnum.MaxValue).ToString()),
+            (value: ByteEnum.MinValue, name: nameof(ByteEnum.MinValue), valueString: ((byte)ByteEnum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: ByteEnum.MaxValue, name: nameof(ByteEnum.MaxValue), valueString: ((byte)ByteEnum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.TryParse<ByteEnum>(x.name, true, out var r1).Should().BeTrue();
             r1.Should().Be(x.value);
 
-            FastEnum.TryParse<ByteEnum>(x.name.ToLower(), true, out var r2).Should().BeTrue();
+            FastEnum.TryParse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), true, out var r2).Should().BeTrue();
             r2.Should().Be(x.value);
 
-            FastEnum.TryParse<ByteEnum>(x.name.ToUpper(), true, out var r3).Should().BeTrue();
+            FastEnum.TryParse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), true, out var r3).Should().BeTrue();
             r3.Should().Be(x.value);
 
             FastEnum.TryParse<ByteEnum>(x.valueString, true, out var r4).Should().BeTrue();
             r4.Should().Be(x.value);
 
-            FastEnum.TryParse<ByteEnum>(x.valueString.ToLower(), true, out var r5).Should().BeTrue();
+            FastEnum.TryParse<ByteEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true, out var r5).Should().BeTrue();
             r5.Should().Be(x.value);
 
-            FastEnum.TryParse<ByteEnum>(x.valueString.ToUpper(), true, out var r6).Should().BeTrue();
+            FastEnum.TryParse<ByteEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true, out var r6).Should().BeTrue();
             r6.Should().Be(x.value);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<ByteEnum>(x, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<ByteEnum>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<ByteEnum>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<ByteEnum>(" ", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<ByteEnum>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<ByteEnum>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((ByteEnum)123);
     }
 
 
@@ -910,22 +1069,53 @@ public sealed class Int16Tests
     {
         var parameters = new[]
         {
-            (value: Int16Enum.MinValue, name: nameof(Int16Enum.MinValue), valueString: ((short)Int16Enum.MinValue).ToString()),
-            (value: Int16Enum.Zero,     name: nameof(Int16Enum.Zero),     valueString: ((short)Int16Enum.Zero).ToString()),
-            (value: Int16Enum.MaxValue, name: nameof(Int16Enum.MaxValue), valueString: ((short)Int16Enum.MaxValue).ToString()),
+            (value: Int16Enum.MinValue, name: nameof(Int16Enum.MinValue), valueString: ((short)Int16Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int16Enum.Zero,     name: nameof(Int16Enum.Zero),     valueString: ((short)Int16Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int16Enum.MaxValue, name: nameof(Int16Enum.MaxValue), valueString: ((short)Int16Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.Parse<Int16Enum>(x.name).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<Int16Enum>(x.name.ToLower())).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<Int16Enum>(x.name.ToUpper())).Should().Throw<ArgumentException>();
-            FastEnum.Parse<Int16Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(x.valueString.ToLower()).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(x.valueString.ToUpper()).Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.Parse<Int16Enum>(x.name).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FastEnum.Parse<Int16Enum>(x.valueString).Should().Be(x.value);
+                FastEnum.Parse<Int16Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
+                FastEnum.Parse<Int16Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<Int16Enum>("123").Should().Be((Int16Enum)123);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("ABCDE")).Should().Throw<ArgumentException>();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.Parse<Int16Enum>(nameUtf8).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<Int16Enum>(nameUtf8Lower)).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<Int16Enum>(nameUtf8Upper)).Should().Throw<ArgumentException>();
+                FastEnum.Parse<Int16Enum>(valueUtf8).Should().Be(x.value);
+                FastEnum.Parse<Int16Enum>(valueUtf8Lower).Should().Be(x.value);
+                FastEnum.Parse<Int16Enum>(valueUtf8Upper).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<Int16Enum>("123"u8).Should().Be((Int16Enum)123);
+        }
     }
 
 
@@ -934,22 +1124,24 @@ public sealed class Int16Tests
     {
         var parameters = new[]
         {
-            (value: Int16Enum.MinValue, name: nameof(Int16Enum.MinValue), valueString: ((short)Int16Enum.MinValue).ToString()),
-            (value: Int16Enum.Zero,     name: nameof(Int16Enum.Zero),     valueString: ((short)Int16Enum.Zero).ToString()),
-            (value: Int16Enum.MaxValue, name: nameof(Int16Enum.MaxValue), valueString: ((short)Int16Enum.MaxValue).ToString()),
+            (value: Int16Enum.MinValue, name: nameof(Int16Enum.MinValue), valueString: ((short)Int16Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int16Enum.Zero,     name: nameof(Int16Enum.Zero),     valueString: ((short)Int16Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int16Enum.MaxValue, name: nameof(Int16Enum.MaxValue), valueString: ((short)Int16Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.Parse<Int16Enum>(x.name, true).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(x.name.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(x.name.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<Int16Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<Int16Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<Int16Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<Int16Enum>("123").Should().Be((Int16Enum)123);
     }
 
 
@@ -958,29 +1150,71 @@ public sealed class Int16Tests
     {
         var parameters = new[]
         {
-            (value: Int16Enum.MinValue, name: nameof(Int16Enum.MinValue), valueString: ((short)Int16Enum.MinValue).ToString()),
-            (value: Int16Enum.Zero,     name: nameof(Int16Enum.Zero),     valueString: ((short)Int16Enum.Zero).ToString()),
-            (value: Int16Enum.MaxValue, name: nameof(Int16Enum.MaxValue), valueString: ((short)Int16Enum.MaxValue).ToString()),
+            (value: Int16Enum.MinValue, name: nameof(Int16Enum.MinValue), valueString: ((short)Int16Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int16Enum.Zero,     name: nameof(Int16Enum.Zero),     valueString: ((short)Int16Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int16Enum.MaxValue, name: nameof(Int16Enum.MaxValue), valueString: ((short)Int16Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.TryParse<Int16Enum>(x.name, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.TryParse<Int16Enum>(x.name, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
 
-            FastEnum.TryParse<Int16Enum>(x.name.ToLower(), out var _).Should().BeFalse();
-            FastEnum.TryParse<Int16Enum>(x.name.ToUpper(), out var _).Should().BeFalse();
+                FastEnum.TryParse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
 
-            FastEnum.TryParse<Int16Enum>(x.valueString, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+                FastEnum.TryParse<Int16Enum>(x.valueString, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
 
-            FastEnum.TryParse<Int16Enum>(x.valueString.ToLower(), out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+                FastEnum.TryParse<Int16Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
 
-            FastEnum.TryParse<Int16Enum>(x.valueString.ToUpper(), out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+                FastEnum.TryParse<Int16Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<Int16Enum>((string?)null, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int16Enum>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<Int16Enum>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<Int16Enum>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<Int16Enum>("123", out var r).Should().BeTrue();
+            r.Should().Be((Int16Enum)123);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<Int16Enum>(x, out var _).Should().BeFalse();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.TryParse<Int16Enum>(nameUtf8, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
+
+                FastEnum.TryParse<Int16Enum>(nameUtf8Lower, out var _).Should().BeFalse();
+                FastEnum.TryParse<Int16Enum>(nameUtf8Upper, out var _).Should().BeFalse();
+
+                FastEnum.TryParse<Int16Enum>(valueUtf8, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
+
+                FastEnum.TryParse<Int16Enum>(valueUtf8Lower, out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
+
+                FastEnum.TryParse<Int16Enum>(valueUtf8Upper, out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<Int16Enum>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int16Enum>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int16Enum>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int16Enum>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((Int16Enum)123);
+        }
     }
 
 
@@ -989,32 +1223,36 @@ public sealed class Int16Tests
     {
         var parameters = new[]
         {
-            (value: Int16Enum.MinValue, name: nameof(Int16Enum.MinValue), valueString: ((short)Int16Enum.MinValue).ToString()),
-            (value: Int16Enum.Zero,     name: nameof(Int16Enum.Zero),     valueString: ((short)Int16Enum.Zero).ToString()),
-            (value: Int16Enum.MaxValue, name: nameof(Int16Enum.MaxValue), valueString: ((short)Int16Enum.MaxValue).ToString()),
+            (value: Int16Enum.MinValue, name: nameof(Int16Enum.MinValue), valueString: ((short)Int16Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int16Enum.Zero,     name: nameof(Int16Enum.Zero),     valueString: ((short)Int16Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int16Enum.MaxValue, name: nameof(Int16Enum.MaxValue), valueString: ((short)Int16Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.TryParse<Int16Enum>(x.name, true, out var r1).Should().BeTrue();
             r1.Should().Be(x.value);
 
-            FastEnum.TryParse<Int16Enum>(x.name.ToLower(), true, out var r2).Should().BeTrue();
+            FastEnum.TryParse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true, out var r2).Should().BeTrue();
             r2.Should().Be(x.value);
 
-            FastEnum.TryParse<Int16Enum>(x.name.ToUpper(), true, out var r3).Should().BeTrue();
+            FastEnum.TryParse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true, out var r3).Should().BeTrue();
             r3.Should().Be(x.value);
 
             FastEnum.TryParse<Int16Enum>(x.valueString, true, out var r4).Should().BeTrue();
             r4.Should().Be(x.value);
 
-            FastEnum.TryParse<Int16Enum>(x.valueString.ToLower(), true, out var r5).Should().BeTrue();
+            FastEnum.TryParse<Int16Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true, out var r5).Should().BeTrue();
             r5.Should().Be(x.value);
 
-            FastEnum.TryParse<Int16Enum>(x.valueString.ToUpper(), true, out var r6).Should().BeTrue();
+            FastEnum.TryParse<Int16Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true, out var r6).Should().BeTrue();
             r6.Should().Be(x.value);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<Int16Enum>(x, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int16Enum>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int16Enum>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int16Enum>(" ", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int16Enum>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int16Enum>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((Int16Enum)123);
     }
 
 
@@ -1263,21 +1501,52 @@ public sealed class UInt16Tests
     {
         var parameters = new[]
         {
-            (value: UInt16Enum.MinValue, name: nameof(UInt16Enum.MinValue), valueString: ((ushort)UInt16Enum.MinValue).ToString()),
-            (value: UInt16Enum.MaxValue, name: nameof(UInt16Enum.MaxValue), valueString: ((ushort)UInt16Enum.MaxValue).ToString()),
+            (value: UInt16Enum.MinValue, name: nameof(UInt16Enum.MinValue), valueString: ((ushort)UInt16Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt16Enum.MaxValue, name: nameof(UInt16Enum.MaxValue), valueString: ((ushort)UInt16Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.Parse<UInt16Enum>(x.name).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<UInt16Enum>(x.name.ToLower())).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<UInt16Enum>(x.name.ToUpper())).Should().Throw<ArgumentException>();
-            FastEnum.Parse<UInt16Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(x.valueString.ToLower()).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(x.valueString.ToUpper()).Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.Parse<UInt16Enum>(x.name).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FastEnum.Parse<UInt16Enum>(x.valueString).Should().Be(x.value);
+                FastEnum.Parse<UInt16Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
+                FastEnum.Parse<UInt16Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<UInt16Enum>("123").Should().Be((UInt16Enum)123);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("ABCDE")).Should().Throw<ArgumentException>();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.Parse<UInt16Enum>(nameUtf8).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<UInt16Enum>(nameUtf8Lower)).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<UInt16Enum>(nameUtf8Upper)).Should().Throw<ArgumentException>();
+                FastEnum.Parse<UInt16Enum>(valueUtf8).Should().Be(x.value);
+                FastEnum.Parse<UInt16Enum>(valueUtf8Lower).Should().Be(x.value);
+                FastEnum.Parse<UInt16Enum>(valueUtf8Upper).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<UInt16Enum>("123"u8).Should().Be((UInt16Enum)123);
+        }
     }
 
 
@@ -1286,21 +1555,23 @@ public sealed class UInt16Tests
     {
         var parameters = new[]
         {
-            (value: UInt16Enum.MinValue, name: nameof(UInt16Enum.MinValue), valueString: ((ushort)UInt16Enum.MinValue).ToString()),
-            (value: UInt16Enum.MaxValue, name: nameof(UInt16Enum.MaxValue), valueString: ((ushort)UInt16Enum.MaxValue).ToString()),
+            (value: UInt16Enum.MinValue, name: nameof(UInt16Enum.MinValue), valueString: ((ushort)UInt16Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt16Enum.MaxValue, name: nameof(UInt16Enum.MaxValue), valueString: ((ushort)UInt16Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.Parse<UInt16Enum>(x.name, true).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(x.name.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(x.name.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<UInt16Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<UInt16Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<UInt16Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<UInt16Enum>("123").Should().Be((UInt16Enum)123);
     }
 
 
@@ -1309,28 +1580,70 @@ public sealed class UInt16Tests
     {
         var parameters = new[]
         {
-            (value: UInt16Enum.MinValue, name: nameof(UInt16Enum.MinValue), valueString: ((ushort)UInt16Enum.MinValue).ToString()),
-            (value: UInt16Enum.MaxValue, name: nameof(UInt16Enum.MaxValue), valueString: ((ushort)UInt16Enum.MaxValue).ToString()),
+            (value: UInt16Enum.MinValue, name: nameof(UInt16Enum.MinValue), valueString: ((ushort)UInt16Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt16Enum.MaxValue, name: nameof(UInt16Enum.MaxValue), valueString: ((ushort)UInt16Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.TryParse<UInt16Enum>(x.name, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.TryParse<UInt16Enum>(x.name, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(x.name.ToLower(), out var _).Should().BeFalse();
-            FastEnum.TryParse<UInt16Enum>(x.name.ToUpper(), out var _).Should().BeFalse();
+                FastEnum.TryParse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
 
-            FastEnum.TryParse<UInt16Enum>(x.valueString, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+                FastEnum.TryParse<UInt16Enum>(x.valueString, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(x.valueString.ToLower(), out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+                FastEnum.TryParse<UInt16Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(x.valueString.ToUpper(), out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+                FastEnum.TryParse<UInt16Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<UInt16Enum>((string?)null, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt16Enum>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt16Enum>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt16Enum>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt16Enum>("123", out var r).Should().BeTrue();
+            r.Should().Be((UInt16Enum)123);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<UInt16Enum>(x, out var _).Should().BeFalse();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.TryParse<UInt16Enum>(nameUtf8, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
+
+                FastEnum.TryParse<UInt16Enum>(nameUtf8Lower, out var _).Should().BeFalse();
+                FastEnum.TryParse<UInt16Enum>(nameUtf8Upper, out var _).Should().BeFalse();
+
+                FastEnum.TryParse<UInt16Enum>(valueUtf8, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
+
+                FastEnum.TryParse<UInt16Enum>(valueUtf8Lower, out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
+
+                FastEnum.TryParse<UInt16Enum>(valueUtf8Upper, out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<UInt16Enum>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt16Enum>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt16Enum>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt16Enum>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((UInt16Enum)123);
+        }
     }
 
 
@@ -1339,31 +1652,35 @@ public sealed class UInt16Tests
     {
         var parameters = new[]
         {
-            (value: UInt16Enum.MinValue, name: nameof(UInt16Enum.MinValue), valueString: ((ushort)UInt16Enum.MinValue).ToString()),
-            (value: UInt16Enum.MaxValue, name: nameof(UInt16Enum.MaxValue), valueString: ((ushort)UInt16Enum.MaxValue).ToString()),
+            (value: UInt16Enum.MinValue, name: nameof(UInt16Enum.MinValue), valueString: ((ushort)UInt16Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt16Enum.MaxValue, name: nameof(UInt16Enum.MaxValue), valueString: ((ushort)UInt16Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.TryParse<UInt16Enum>(x.name, true, out var r1).Should().BeTrue();
             r1.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(x.name.ToLower(), true, out var r2).Should().BeTrue();
+            FastEnum.TryParse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true, out var r2).Should().BeTrue();
             r2.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(x.name.ToUpper(), true, out var r3).Should().BeTrue();
+            FastEnum.TryParse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true, out var r3).Should().BeTrue();
             r3.Should().Be(x.value);
 
             FastEnum.TryParse<UInt16Enum>(x.valueString, true, out var r4).Should().BeTrue();
             r4.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(x.valueString.ToLower(), true, out var r5).Should().BeTrue();
+            FastEnum.TryParse<UInt16Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true, out var r5).Should().BeTrue();
             r5.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(x.valueString.ToUpper(), true, out var r6).Should().BeTrue();
+            FastEnum.TryParse<UInt16Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true, out var r6).Should().BeTrue();
             r6.Should().Be(x.value);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<UInt16Enum>(x, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt16Enum>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt16Enum>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt16Enum>(" ", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt16Enum>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt16Enum>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((UInt16Enum)123);
     }
 
 
@@ -1615,22 +1932,53 @@ public sealed class Int32Tests
     {
         var parameters = new[]
         {
-            (value: Int32Enum.MinValue, name: nameof(Int32Enum.MinValue), valueString: ((int)Int32Enum.MinValue).ToString()),
-            (value: Int32Enum.Zero,     name: nameof(Int32Enum.Zero),     valueString: ((int)Int32Enum.Zero).ToString()),
-            (value: Int32Enum.MaxValue, name: nameof(Int32Enum.MaxValue), valueString: ((int)Int32Enum.MaxValue).ToString()),
+            (value: Int32Enum.MinValue, name: nameof(Int32Enum.MinValue), valueString: ((int)Int32Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int32Enum.Zero,     name: nameof(Int32Enum.Zero),     valueString: ((int)Int32Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int32Enum.MaxValue, name: nameof(Int32Enum.MaxValue), valueString: ((int)Int32Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.Parse<Int32Enum>(x.name).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<Int32Enum>(x.name.ToLower())).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<Int32Enum>(x.name.ToUpper())).Should().Throw<ArgumentException>();
-            FastEnum.Parse<Int32Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(x.valueString.ToLower()).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(x.valueString.ToUpper()).Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.Parse<Int32Enum>(x.name).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FastEnum.Parse<Int32Enum>(x.valueString).Should().Be(x.value);
+                FastEnum.Parse<Int32Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
+                FastEnum.Parse<Int32Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<Int32Enum>("123").Should().Be((Int32Enum)123);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("ABCDE")).Should().Throw<ArgumentException>();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.Parse<Int32Enum>(nameUtf8).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<Int32Enum>(nameUtf8Lower)).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<Int32Enum>(nameUtf8Upper)).Should().Throw<ArgumentException>();
+                FastEnum.Parse<Int32Enum>(valueUtf8).Should().Be(x.value);
+                FastEnum.Parse<Int32Enum>(valueUtf8Lower).Should().Be(x.value);
+                FastEnum.Parse<Int32Enum>(valueUtf8Upper).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<Int32Enum>("123"u8).Should().Be((Int32Enum)123);
+        }
     }
 
 
@@ -1639,22 +1987,24 @@ public sealed class Int32Tests
     {
         var parameters = new[]
         {
-            (value: Int32Enum.MinValue, name: nameof(Int32Enum.MinValue), valueString: ((int)Int32Enum.MinValue).ToString()),
-            (value: Int32Enum.Zero,     name: nameof(Int32Enum.Zero),     valueString: ((int)Int32Enum.Zero).ToString()),
-            (value: Int32Enum.MaxValue, name: nameof(Int32Enum.MaxValue), valueString: ((int)Int32Enum.MaxValue).ToString()),
+            (value: Int32Enum.MinValue, name: nameof(Int32Enum.MinValue), valueString: ((int)Int32Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int32Enum.Zero,     name: nameof(Int32Enum.Zero),     valueString: ((int)Int32Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int32Enum.MaxValue, name: nameof(Int32Enum.MaxValue), valueString: ((int)Int32Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.Parse<Int32Enum>(x.name, true).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(x.name.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(x.name.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<Int32Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<Int32Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<Int32Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<Int32Enum>("123").Should().Be((Int32Enum)123);
     }
 
 
@@ -1663,29 +2013,71 @@ public sealed class Int32Tests
     {
         var parameters = new[]
         {
-            (value: Int32Enum.MinValue, name: nameof(Int32Enum.MinValue), valueString: ((int)Int32Enum.MinValue).ToString()),
-            (value: Int32Enum.Zero,     name: nameof(Int32Enum.Zero),     valueString: ((int)Int32Enum.Zero).ToString()),
-            (value: Int32Enum.MaxValue, name: nameof(Int32Enum.MaxValue), valueString: ((int)Int32Enum.MaxValue).ToString()),
+            (value: Int32Enum.MinValue, name: nameof(Int32Enum.MinValue), valueString: ((int)Int32Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int32Enum.Zero,     name: nameof(Int32Enum.Zero),     valueString: ((int)Int32Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int32Enum.MaxValue, name: nameof(Int32Enum.MaxValue), valueString: ((int)Int32Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.TryParse<Int32Enum>(x.name, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.TryParse<Int32Enum>(x.name, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
 
-            FastEnum.TryParse<Int32Enum>(x.name.ToLower(), out var _).Should().BeFalse();
-            FastEnum.TryParse<Int32Enum>(x.name.ToUpper(), out var _).Should().BeFalse();
+                FastEnum.TryParse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
 
-            FastEnum.TryParse<Int32Enum>(x.valueString, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+                FastEnum.TryParse<Int32Enum>(x.valueString, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
 
-            FastEnum.TryParse<Int32Enum>(x.valueString.ToLower(), out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+                FastEnum.TryParse<Int32Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
 
-            FastEnum.TryParse<Int32Enum>(x.valueString.ToUpper(), out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+                FastEnum.TryParse<Int32Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<Int32Enum>((string?)null, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int32Enum>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<Int32Enum>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<Int32Enum>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<Int32Enum>("123", out var r).Should().BeTrue();
+            r.Should().Be((Int32Enum)123);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<Int32Enum>(x, out var _).Should().BeFalse();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.TryParse<Int32Enum>(nameUtf8, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
+
+                FastEnum.TryParse<Int32Enum>(nameUtf8Lower, out var _).Should().BeFalse();
+                FastEnum.TryParse<Int32Enum>(nameUtf8Upper, out var _).Should().BeFalse();
+
+                FastEnum.TryParse<Int32Enum>(valueUtf8, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
+
+                FastEnum.TryParse<Int32Enum>(valueUtf8Lower, out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
+
+                FastEnum.TryParse<Int32Enum>(valueUtf8Upper, out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<Int32Enum>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int32Enum>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int32Enum>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int32Enum>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((Int32Enum)123);
+        }
     }
 
 
@@ -1694,32 +2086,36 @@ public sealed class Int32Tests
     {
         var parameters = new[]
         {
-            (value: Int32Enum.MinValue, name: nameof(Int32Enum.MinValue), valueString: ((int)Int32Enum.MinValue).ToString()),
-            (value: Int32Enum.Zero,     name: nameof(Int32Enum.Zero),     valueString: ((int)Int32Enum.Zero).ToString()),
-            (value: Int32Enum.MaxValue, name: nameof(Int32Enum.MaxValue), valueString: ((int)Int32Enum.MaxValue).ToString()),
+            (value: Int32Enum.MinValue, name: nameof(Int32Enum.MinValue), valueString: ((int)Int32Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int32Enum.Zero,     name: nameof(Int32Enum.Zero),     valueString: ((int)Int32Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int32Enum.MaxValue, name: nameof(Int32Enum.MaxValue), valueString: ((int)Int32Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.TryParse<Int32Enum>(x.name, true, out var r1).Should().BeTrue();
             r1.Should().Be(x.value);
 
-            FastEnum.TryParse<Int32Enum>(x.name.ToLower(), true, out var r2).Should().BeTrue();
+            FastEnum.TryParse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true, out var r2).Should().BeTrue();
             r2.Should().Be(x.value);
 
-            FastEnum.TryParse<Int32Enum>(x.name.ToUpper(), true, out var r3).Should().BeTrue();
+            FastEnum.TryParse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true, out var r3).Should().BeTrue();
             r3.Should().Be(x.value);
 
             FastEnum.TryParse<Int32Enum>(x.valueString, true, out var r4).Should().BeTrue();
             r4.Should().Be(x.value);
 
-            FastEnum.TryParse<Int32Enum>(x.valueString.ToLower(), true, out var r5).Should().BeTrue();
+            FastEnum.TryParse<Int32Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true, out var r5).Should().BeTrue();
             r5.Should().Be(x.value);
 
-            FastEnum.TryParse<Int32Enum>(x.valueString.ToUpper(), true, out var r6).Should().BeTrue();
+            FastEnum.TryParse<Int32Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true, out var r6).Should().BeTrue();
             r6.Should().Be(x.value);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<Int32Enum>(x, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int32Enum>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int32Enum>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int32Enum>(" ", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int32Enum>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int32Enum>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((Int32Enum)123);
     }
 
 
@@ -1968,21 +2364,52 @@ public sealed class UInt32Tests
     {
         var parameters = new[]
         {
-            (value: UInt32Enum.MinValue, name: nameof(UInt32Enum.MinValue), valueString: ((uint)UInt32Enum.MinValue).ToString()),
-            (value: UInt32Enum.MaxValue, name: nameof(UInt32Enum.MaxValue), valueString: ((uint)UInt32Enum.MaxValue).ToString()),
+            (value: UInt32Enum.MinValue, name: nameof(UInt32Enum.MinValue), valueString: ((uint)UInt32Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt32Enum.MaxValue, name: nameof(UInt32Enum.MaxValue), valueString: ((uint)UInt32Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.Parse<UInt32Enum>(x.name).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<UInt32Enum>(x.name.ToLower())).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<UInt32Enum>(x.name.ToUpper())).Should().Throw<ArgumentException>();
-            FastEnum.Parse<UInt32Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(x.valueString.ToLower()).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(x.valueString.ToUpper()).Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.Parse<UInt32Enum>(x.name).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FastEnum.Parse<UInt32Enum>(x.valueString).Should().Be(x.value);
+                FastEnum.Parse<UInt32Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
+                FastEnum.Parse<UInt32Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<UInt32Enum>("123").Should().Be((UInt32Enum)123);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("ABCDE")).Should().Throw<ArgumentException>();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.Parse<UInt32Enum>(nameUtf8).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<UInt32Enum>(nameUtf8Lower)).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<UInt32Enum>(nameUtf8Upper)).Should().Throw<ArgumentException>();
+                FastEnum.Parse<UInt32Enum>(valueUtf8).Should().Be(x.value);
+                FastEnum.Parse<UInt32Enum>(valueUtf8Lower).Should().Be(x.value);
+                FastEnum.Parse<UInt32Enum>(valueUtf8Upper).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<UInt32Enum>("123"u8).Should().Be((UInt32Enum)123);
+        }
     }
 
 
@@ -1991,21 +2418,23 @@ public sealed class UInt32Tests
     {
         var parameters = new[]
         {
-            (value: UInt32Enum.MinValue, name: nameof(UInt32Enum.MinValue), valueString: ((uint)UInt32Enum.MinValue).ToString()),
-            (value: UInt32Enum.MaxValue, name: nameof(UInt32Enum.MaxValue), valueString: ((uint)UInt32Enum.MaxValue).ToString()),
+            (value: UInt32Enum.MinValue, name: nameof(UInt32Enum.MinValue), valueString: ((uint)UInt32Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt32Enum.MaxValue, name: nameof(UInt32Enum.MaxValue), valueString: ((uint)UInt32Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.Parse<UInt32Enum>(x.name, true).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(x.name.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(x.name.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<UInt32Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<UInt32Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<UInt32Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<UInt32Enum>("123").Should().Be((UInt32Enum)123);
     }
 
 
@@ -2014,28 +2443,70 @@ public sealed class UInt32Tests
     {
         var parameters = new[]
         {
-            (value: UInt32Enum.MinValue, name: nameof(UInt32Enum.MinValue), valueString: ((uint)UInt32Enum.MinValue).ToString()),
-            (value: UInt32Enum.MaxValue, name: nameof(UInt32Enum.MaxValue), valueString: ((uint)UInt32Enum.MaxValue).ToString()),
+            (value: UInt32Enum.MinValue, name: nameof(UInt32Enum.MinValue), valueString: ((uint)UInt32Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt32Enum.MaxValue, name: nameof(UInt32Enum.MaxValue), valueString: ((uint)UInt32Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.TryParse<UInt32Enum>(x.name, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.TryParse<UInt32Enum>(x.name, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(x.name.ToLower(), out var _).Should().BeFalse();
-            FastEnum.TryParse<UInt32Enum>(x.name.ToUpper(), out var _).Should().BeFalse();
+                FastEnum.TryParse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
 
-            FastEnum.TryParse<UInt32Enum>(x.valueString, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+                FastEnum.TryParse<UInt32Enum>(x.valueString, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(x.valueString.ToLower(), out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+                FastEnum.TryParse<UInt32Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(x.valueString.ToUpper(), out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+                FastEnum.TryParse<UInt32Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<UInt32Enum>((string?)null, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt32Enum>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt32Enum>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt32Enum>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt32Enum>("123", out var r).Should().BeTrue();
+            r.Should().Be((UInt32Enum)123);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<UInt32Enum>(x, out var _).Should().BeFalse();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.TryParse<UInt32Enum>(nameUtf8, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
+
+                FastEnum.TryParse<UInt32Enum>(nameUtf8Lower, out var _).Should().BeFalse();
+                FastEnum.TryParse<UInt32Enum>(nameUtf8Upper, out var _).Should().BeFalse();
+
+                FastEnum.TryParse<UInt32Enum>(valueUtf8, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
+
+                FastEnum.TryParse<UInt32Enum>(valueUtf8Lower, out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
+
+                FastEnum.TryParse<UInt32Enum>(valueUtf8Upper, out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<UInt32Enum>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt32Enum>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt32Enum>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt32Enum>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((UInt32Enum)123);
+        }
     }
 
 
@@ -2044,31 +2515,35 @@ public sealed class UInt32Tests
     {
         var parameters = new[]
         {
-            (value: UInt32Enum.MinValue, name: nameof(UInt32Enum.MinValue), valueString: ((uint)UInt32Enum.MinValue).ToString()),
-            (value: UInt32Enum.MaxValue, name: nameof(UInt32Enum.MaxValue), valueString: ((uint)UInt32Enum.MaxValue).ToString()),
+            (value: UInt32Enum.MinValue, name: nameof(UInt32Enum.MinValue), valueString: ((uint)UInt32Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt32Enum.MaxValue, name: nameof(UInt32Enum.MaxValue), valueString: ((uint)UInt32Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.TryParse<UInt32Enum>(x.name, true, out var r1).Should().BeTrue();
             r1.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(x.name.ToLower(), true, out var r2).Should().BeTrue();
+            FastEnum.TryParse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true, out var r2).Should().BeTrue();
             r2.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(x.name.ToUpper(), true, out var r3).Should().BeTrue();
+            FastEnum.TryParse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true, out var r3).Should().BeTrue();
             r3.Should().Be(x.value);
 
             FastEnum.TryParse<UInt32Enum>(x.valueString, true, out var r4).Should().BeTrue();
             r4.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(x.valueString.ToLower(), true, out var r5).Should().BeTrue();
+            FastEnum.TryParse<UInt32Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true, out var r5).Should().BeTrue();
             r5.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(x.valueString.ToUpper(), true, out var r6).Should().BeTrue();
+            FastEnum.TryParse<UInt32Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true, out var r6).Should().BeTrue();
             r6.Should().Be(x.value);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<UInt32Enum>(x, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt32Enum>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt32Enum>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt32Enum>(" ", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt32Enum>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt32Enum>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((UInt32Enum)123);
     }
 
 
@@ -2320,22 +2795,53 @@ public sealed class Int64Tests
     {
         var parameters = new[]
         {
-            (value: Int64Enum.MinValue, name: nameof(Int64Enum.MinValue), valueString: ((long)Int64Enum.MinValue).ToString()),
-            (value: Int64Enum.Zero,     name: nameof(Int64Enum.Zero),     valueString: ((long)Int64Enum.Zero).ToString()),
-            (value: Int64Enum.MaxValue, name: nameof(Int64Enum.MaxValue), valueString: ((long)Int64Enum.MaxValue).ToString()),
+            (value: Int64Enum.MinValue, name: nameof(Int64Enum.MinValue), valueString: ((long)Int64Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int64Enum.Zero,     name: nameof(Int64Enum.Zero),     valueString: ((long)Int64Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int64Enum.MaxValue, name: nameof(Int64Enum.MaxValue), valueString: ((long)Int64Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.Parse<Int64Enum>(x.name).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<Int64Enum>(x.name.ToLower())).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<Int64Enum>(x.name.ToUpper())).Should().Throw<ArgumentException>();
-            FastEnum.Parse<Int64Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(x.valueString.ToLower()).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(x.valueString.ToUpper()).Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.Parse<Int64Enum>(x.name).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FastEnum.Parse<Int64Enum>(x.valueString).Should().Be(x.value);
+                FastEnum.Parse<Int64Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
+                FastEnum.Parse<Int64Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<Int64Enum>("123").Should().Be((Int64Enum)123);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("ABCDE")).Should().Throw<ArgumentException>();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.Parse<Int64Enum>(nameUtf8).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<Int64Enum>(nameUtf8Lower)).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<Int64Enum>(nameUtf8Upper)).Should().Throw<ArgumentException>();
+                FastEnum.Parse<Int64Enum>(valueUtf8).Should().Be(x.value);
+                FastEnum.Parse<Int64Enum>(valueUtf8Lower).Should().Be(x.value);
+                FastEnum.Parse<Int64Enum>(valueUtf8Upper).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<Int64Enum>("123"u8).Should().Be((Int64Enum)123);
+        }
     }
 
 
@@ -2344,22 +2850,24 @@ public sealed class Int64Tests
     {
         var parameters = new[]
         {
-            (value: Int64Enum.MinValue, name: nameof(Int64Enum.MinValue), valueString: ((long)Int64Enum.MinValue).ToString()),
-            (value: Int64Enum.Zero,     name: nameof(Int64Enum.Zero),     valueString: ((long)Int64Enum.Zero).ToString()),
-            (value: Int64Enum.MaxValue, name: nameof(Int64Enum.MaxValue), valueString: ((long)Int64Enum.MaxValue).ToString()),
+            (value: Int64Enum.MinValue, name: nameof(Int64Enum.MinValue), valueString: ((long)Int64Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int64Enum.Zero,     name: nameof(Int64Enum.Zero),     valueString: ((long)Int64Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int64Enum.MaxValue, name: nameof(Int64Enum.MaxValue), valueString: ((long)Int64Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.Parse<Int64Enum>(x.name, true).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(x.name.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(x.name.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<Int64Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<Int64Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<Int64Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<Int64Enum>("123").Should().Be((Int64Enum)123);
     }
 
 
@@ -2368,29 +2876,71 @@ public sealed class Int64Tests
     {
         var parameters = new[]
         {
-            (value: Int64Enum.MinValue, name: nameof(Int64Enum.MinValue), valueString: ((long)Int64Enum.MinValue).ToString()),
-            (value: Int64Enum.Zero,     name: nameof(Int64Enum.Zero),     valueString: ((long)Int64Enum.Zero).ToString()),
-            (value: Int64Enum.MaxValue, name: nameof(Int64Enum.MaxValue), valueString: ((long)Int64Enum.MaxValue).ToString()),
+            (value: Int64Enum.MinValue, name: nameof(Int64Enum.MinValue), valueString: ((long)Int64Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int64Enum.Zero,     name: nameof(Int64Enum.Zero),     valueString: ((long)Int64Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int64Enum.MaxValue, name: nameof(Int64Enum.MaxValue), valueString: ((long)Int64Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.TryParse<Int64Enum>(x.name, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.TryParse<Int64Enum>(x.name, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
 
-            FastEnum.TryParse<Int64Enum>(x.name.ToLower(), out var _).Should().BeFalse();
-            FastEnum.TryParse<Int64Enum>(x.name.ToUpper(), out var _).Should().BeFalse();
+                FastEnum.TryParse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
 
-            FastEnum.TryParse<Int64Enum>(x.valueString, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+                FastEnum.TryParse<Int64Enum>(x.valueString, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
 
-            FastEnum.TryParse<Int64Enum>(x.valueString.ToLower(), out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+                FastEnum.TryParse<Int64Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
 
-            FastEnum.TryParse<Int64Enum>(x.valueString.ToUpper(), out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+                FastEnum.TryParse<Int64Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<Int64Enum>((string?)null, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int64Enum>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<Int64Enum>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<Int64Enum>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<Int64Enum>("123", out var r).Should().BeTrue();
+            r.Should().Be((Int64Enum)123);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<Int64Enum>(x, out var _).Should().BeFalse();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.TryParse<Int64Enum>(nameUtf8, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
+
+                FastEnum.TryParse<Int64Enum>(nameUtf8Lower, out var _).Should().BeFalse();
+                FastEnum.TryParse<Int64Enum>(nameUtf8Upper, out var _).Should().BeFalse();
+
+                FastEnum.TryParse<Int64Enum>(valueUtf8, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
+
+                FastEnum.TryParse<Int64Enum>(valueUtf8Lower, out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
+
+                FastEnum.TryParse<Int64Enum>(valueUtf8Upper, out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<Int64Enum>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int64Enum>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int64Enum>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int64Enum>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((Int64Enum)123);
+        }
     }
 
 
@@ -2399,32 +2949,36 @@ public sealed class Int64Tests
     {
         var parameters = new[]
         {
-            (value: Int64Enum.MinValue, name: nameof(Int64Enum.MinValue), valueString: ((long)Int64Enum.MinValue).ToString()),
-            (value: Int64Enum.Zero,     name: nameof(Int64Enum.Zero),     valueString: ((long)Int64Enum.Zero).ToString()),
-            (value: Int64Enum.MaxValue, name: nameof(Int64Enum.MaxValue), valueString: ((long)Int64Enum.MaxValue).ToString()),
+            (value: Int64Enum.MinValue, name: nameof(Int64Enum.MinValue), valueString: ((long)Int64Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: Int64Enum.Zero,     name: nameof(Int64Enum.Zero),     valueString: ((long)Int64Enum.Zero).ToString(CultureInfo.InvariantCulture)),
+            (value: Int64Enum.MaxValue, name: nameof(Int64Enum.MaxValue), valueString: ((long)Int64Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.TryParse<Int64Enum>(x.name, true, out var r1).Should().BeTrue();
             r1.Should().Be(x.value);
 
-            FastEnum.TryParse<Int64Enum>(x.name.ToLower(), true, out var r2).Should().BeTrue();
+            FastEnum.TryParse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true, out var r2).Should().BeTrue();
             r2.Should().Be(x.value);
 
-            FastEnum.TryParse<Int64Enum>(x.name.ToUpper(), true, out var r3).Should().BeTrue();
+            FastEnum.TryParse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true, out var r3).Should().BeTrue();
             r3.Should().Be(x.value);
 
             FastEnum.TryParse<Int64Enum>(x.valueString, true, out var r4).Should().BeTrue();
             r4.Should().Be(x.value);
 
-            FastEnum.TryParse<Int64Enum>(x.valueString.ToLower(), true, out var r5).Should().BeTrue();
+            FastEnum.TryParse<Int64Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true, out var r5).Should().BeTrue();
             r5.Should().Be(x.value);
 
-            FastEnum.TryParse<Int64Enum>(x.valueString.ToUpper(), true, out var r6).Should().BeTrue();
+            FastEnum.TryParse<Int64Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true, out var r6).Should().BeTrue();
             r6.Should().Be(x.value);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<Int64Enum>(x, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int64Enum>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int64Enum>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int64Enum>(" ", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int64Enum>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<Int64Enum>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((Int64Enum)123);
     }
 
 
@@ -2673,21 +3227,52 @@ public sealed class UInt64Tests
     {
         var parameters = new[]
         {
-            (value: UInt64Enum.MinValue, name: nameof(UInt64Enum.MinValue), valueString: ((ulong)UInt64Enum.MinValue).ToString()),
-            (value: UInt64Enum.MaxValue, name: nameof(UInt64Enum.MaxValue), valueString: ((ulong)UInt64Enum.MaxValue).ToString()),
+            (value: UInt64Enum.MinValue, name: nameof(UInt64Enum.MinValue), valueString: ((ulong)UInt64Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt64Enum.MaxValue, name: nameof(UInt64Enum.MaxValue), valueString: ((ulong)UInt64Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.Parse<UInt64Enum>(x.name).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<UInt64Enum>(x.name.ToLower())).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<UInt64Enum>(x.name.ToUpper())).Should().Throw<ArgumentException>();
-            FastEnum.Parse<UInt64Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(x.valueString.ToLower()).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(x.valueString.ToUpper()).Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.Parse<UInt64Enum>(x.name).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FastEnum.Parse<UInt64Enum>(x.valueString).Should().Be(x.value);
+                FastEnum.Parse<UInt64Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
+                FastEnum.Parse<UInt64Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<UInt64Enum>("123").Should().Be((UInt64Enum)123);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("ABCDE")).Should().Throw<ArgumentException>();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.Parse<UInt64Enum>(nameUtf8).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<UInt64Enum>(nameUtf8Lower)).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<UInt64Enum>(nameUtf8Upper)).Should().Throw<ArgumentException>();
+                FastEnum.Parse<UInt64Enum>(valueUtf8).Should().Be(x.value);
+                FastEnum.Parse<UInt64Enum>(valueUtf8Lower).Should().Be(x.value);
+                FastEnum.Parse<UInt64Enum>(valueUtf8Upper).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<UInt64Enum>("123"u8).Should().Be((UInt64Enum)123);
+        }
     }
 
 
@@ -2696,21 +3281,23 @@ public sealed class UInt64Tests
     {
         var parameters = new[]
         {
-            (value: UInt64Enum.MinValue, name: nameof(UInt64Enum.MinValue), valueString: ((ulong)UInt64Enum.MinValue).ToString()),
-            (value: UInt64Enum.MaxValue, name: nameof(UInt64Enum.MaxValue), valueString: ((ulong)UInt64Enum.MaxValue).ToString()),
+            (value: UInt64Enum.MinValue, name: nameof(UInt64Enum.MinValue), valueString: ((ulong)UInt64Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt64Enum.MaxValue, name: nameof(UInt64Enum.MaxValue), valueString: ((ulong)UInt64Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.Parse<UInt64Enum>(x.name, true).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(x.name.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(x.name.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<UInt64Enum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(x.valueString.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(x.valueString.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<UInt64Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<UInt64Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>((string?)null, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<UInt64Enum>("123").Should().Be((UInt64Enum)123);
     }
 
 
@@ -2719,28 +3306,70 @@ public sealed class UInt64Tests
     {
         var parameters = new[]
         {
-            (value: UInt64Enum.MinValue, name: nameof(UInt64Enum.MinValue), valueString: ((ulong)UInt64Enum.MinValue).ToString()),
-            (value: UInt64Enum.MaxValue, name: nameof(UInt64Enum.MaxValue), valueString: ((ulong)UInt64Enum.MaxValue).ToString()),
+            (value: UInt64Enum.MinValue, name: nameof(UInt64Enum.MinValue), valueString: ((ulong)UInt64Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt64Enum.MaxValue, name: nameof(UInt64Enum.MaxValue), valueString: ((ulong)UInt64Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.TryParse<UInt64Enum>(x.name, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.TryParse<UInt64Enum>(x.name, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(x.name.ToLower(), out var _).Should().BeFalse();
-            FastEnum.TryParse<UInt64Enum>(x.name.ToUpper(), out var _).Should().BeFalse();
+                FastEnum.TryParse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
 
-            FastEnum.TryParse<UInt64Enum>(x.valueString, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+                FastEnum.TryParse<UInt64Enum>(x.valueString, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(x.valueString.ToLower(), out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+                FastEnum.TryParse<UInt64Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(x.valueString.ToUpper(), out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+                FastEnum.TryParse<UInt64Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<UInt64Enum>((string?)null, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt64Enum>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt64Enum>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt64Enum>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt64Enum>("123", out var r).Should().BeTrue();
+            r.Should().Be((UInt64Enum)123);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<UInt64Enum>(x, out var _).Should().BeFalse();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.TryParse<UInt64Enum>(nameUtf8, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
+
+                FastEnum.TryParse<UInt64Enum>(nameUtf8Lower, out var _).Should().BeFalse();
+                FastEnum.TryParse<UInt64Enum>(nameUtf8Upper, out var _).Should().BeFalse();
+
+                FastEnum.TryParse<UInt64Enum>(valueUtf8, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
+
+                FastEnum.TryParse<UInt64Enum>(valueUtf8Lower, out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
+
+                FastEnum.TryParse<UInt64Enum>(valueUtf8Upper, out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<UInt64Enum>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt64Enum>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt64Enum>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt64Enum>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((UInt64Enum)123);
+        }
     }
 
 
@@ -2749,31 +3378,35 @@ public sealed class UInt64Tests
     {
         var parameters = new[]
         {
-            (value: UInt64Enum.MinValue, name: nameof(UInt64Enum.MinValue), valueString: ((ulong)UInt64Enum.MinValue).ToString()),
-            (value: UInt64Enum.MaxValue, name: nameof(UInt64Enum.MaxValue), valueString: ((ulong)UInt64Enum.MaxValue).ToString()),
+            (value: UInt64Enum.MinValue, name: nameof(UInt64Enum.MinValue), valueString: ((ulong)UInt64Enum.MinValue).ToString(CultureInfo.InvariantCulture)),
+            (value: UInt64Enum.MaxValue, name: nameof(UInt64Enum.MaxValue), valueString: ((ulong)UInt64Enum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.TryParse<UInt64Enum>(x.name, true, out var r1).Should().BeTrue();
             r1.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(x.name.ToLower(), true, out var r2).Should().BeTrue();
+            FastEnum.TryParse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), true, out var r2).Should().BeTrue();
             r2.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(x.name.ToUpper(), true, out var r3).Should().BeTrue();
+            FastEnum.TryParse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), true, out var r3).Should().BeTrue();
             r3.Should().Be(x.value);
 
             FastEnum.TryParse<UInt64Enum>(x.valueString, true, out var r4).Should().BeTrue();
             r4.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(x.valueString.ToLower(), true, out var r5).Should().BeTrue();
+            FastEnum.TryParse<UInt64Enum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true, out var r5).Should().BeTrue();
             r5.Should().Be(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(x.valueString.ToUpper(), true, out var r6).Should().BeTrue();
+            FastEnum.TryParse<UInt64Enum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true, out var r6).Should().BeTrue();
             r6.Should().Be(x.value);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<UInt64Enum>(x, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt64Enum>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt64Enum>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt64Enum>(" ", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt64Enum>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<UInt64Enum>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((UInt64Enum)123);
     }
 
 

--- a/src/insights/FastEnum.UnitTests/Cases/BasicTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/BasicTests.tt
@@ -192,6 +192,7 @@ public sealed class <#= x.AliasType #>Tests
     [TestMethod]
     public void IsDefined()
     {
+        //--- IsDefined(TEnum)
         FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.MinValue).Should().BeTrue();
 <# if (x.IsSignedType) { #>
         FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.Zero).Should().BeTrue();
@@ -199,12 +200,14 @@ public sealed class <#= x.AliasType #>Tests
         FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.MaxValue).Should().BeTrue();
         FastEnum.IsDefined<<#= x.EnumType #>>((<#= x.EnumType #>)123).Should().BeFalse();
 
+        //--- Extension methods
         <#= x.EnumType #>.MinValue.IsDefined().Should().BeTrue();
 <# if (x.IsSignedType) { #>
         <#= x.EnumType #>.Zero.IsDefined().Should().BeTrue();
 <# } #>
         <#= x.EnumType #>.MaxValue.IsDefined().Should().BeTrue();
 
+        //--- IsDefined(ReadOnlySpan<char>)
         FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.MinValue)).Should().BeTrue();
 <# if (x.IsSignedType) { #>
         FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.Zero)).Should().BeTrue();
@@ -212,6 +215,15 @@ public sealed class <#= x.AliasType #>Tests
         FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.MaxValue)).Should().BeTrue();
         FastEnum.IsDefined<<#= x.EnumType #>>("123").Should().BeFalse();
         FastEnum.IsDefined<<#= x.EnumType #>>("minvalue").Should().BeFalse();
+
+        //--- IsDefined(ReadOnlySpan<byte>)
+        FastEnum.IsDefined<<#= x.EnumType #>>("MinValue"u8).Should().BeTrue();
+<# if (x.IsSignedType) { #>
+        FastEnum.IsDefined<<#= x.EnumType #>>("Zero"u8).Should().BeTrue();
+<# } #>
+        FastEnum.IsDefined<<#= x.EnumType #>>("MaxValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>("123"u8).Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>("minvalue"u8).Should().BeFalse();
     }
 
 

--- a/src/insights/FastEnum.UnitTests/Cases/BasicTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/BasicTests.tt
@@ -22,6 +22,7 @@
 #nullable enable
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -232,24 +233,55 @@ public sealed class <#= x.AliasType #>Tests
     {
         var parameters = new[]
         {
-            (value: <#= x.EnumType #>.MinValue, name: nameof(<#= x.EnumType #>.MinValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MinValue).ToString()),
+            (value: <#= x.EnumType #>.MinValue, name: nameof(<#= x.EnumType #>.MinValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MinValue).ToString(CultureInfo.InvariantCulture)),
 <# if (x.IsSignedType) { #>
-            (value: <#= x.EnumType #>.Zero,     name: nameof(<#= x.EnumType #>.Zero),     valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.Zero).ToString()),
+            (value: <#= x.EnumType #>.Zero,     name: nameof(<#= x.EnumType #>.Zero),     valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.Zero).ToString(CultureInfo.InvariantCulture)),
 <# } #>
-            (value: <#= x.EnumType #>.MaxValue, name: nameof(<#= x.EnumType #>.MaxValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MaxValue).ToString()),
+            (value: <#= x.EnumType #>.MaxValue, name: nameof(<#= x.EnumType #>.MaxValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.Parse<<#= x.EnumType #>>(x.name).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower())).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper())).Should().Throw<ArgumentException>();
-            FastEnum.Parse<<#= x.EnumType #>>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToLower()).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToUpper()).Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.Parse<<#= x.EnumType #>>(x.name).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FastEnum.Parse<<#= x.EnumType #>>(x.valueString).Should().Be(x.value);
+                FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
+                FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, true)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<<#= x.EnumType #>>("123").Should().Be((<#= x.EnumType #>)123);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE")).Should().Throw<ArgumentException>();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.Parse<<#= x.EnumType #>>(nameUtf8).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(nameUtf8Lower)).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(nameUtf8Upper)).Should().Throw<ArgumentException>();
+                FastEnum.Parse<<#= x.EnumType #>>(valueUtf8).Should().Be(x.value);
+                FastEnum.Parse<<#= x.EnumType #>>(valueUtf8Lower).Should().Be(x.value);
+                FastEnum.Parse<<#= x.EnumType #>>(valueUtf8Upper).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<<#= x.EnumType #>>("123"u8).Should().Be((<#= x.EnumType #>)123);
+        }
     }
 
 
@@ -258,24 +290,26 @@ public sealed class <#= x.AliasType #>Tests
     {
         var parameters = new[]
         {
-            (value: <#= x.EnumType #>.MinValue, name: nameof(<#= x.EnumType #>.MinValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MinValue).ToString()),
+            (value: <#= x.EnumType #>.MinValue, name: nameof(<#= x.EnumType #>.MinValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MinValue).ToString(CultureInfo.InvariantCulture)),
 <# if (x.IsSignedType) { #>
-            (value: <#= x.EnumType #>.Zero,     name: nameof(<#= x.EnumType #>.Zero),     valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.Zero).ToString()),
+            (value: <#= x.EnumType #>.Zero,     name: nameof(<#= x.EnumType #>.Zero),     valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.Zero).ToString(CultureInfo.InvariantCulture)),
 <# } #>
-            (value: <#= x.EnumType #>.MaxValue, name: nameof(<#= x.EnumType #>.MaxValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MaxValue).ToString()),
+            (value: <#= x.EnumType #>.MaxValue, name: nameof(<#= x.EnumType #>.MaxValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.Parse<<#= x.EnumType #>>(x.name, true).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<<#= x.EnumType #>>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToLower(), true).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToUpper(), true).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<<#= x.EnumType #>>("123").Should().Be((<#= x.EnumType #>)123);
     }
 
 
@@ -284,31 +318,73 @@ public sealed class <#= x.AliasType #>Tests
     {
         var parameters = new[]
         {
-            (value: <#= x.EnumType #>.MinValue, name: nameof(<#= x.EnumType #>.MinValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MinValue).ToString()),
+            (value: <#= x.EnumType #>.MinValue, name: nameof(<#= x.EnumType #>.MinValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MinValue).ToString(CultureInfo.InvariantCulture)),
 <# if (x.IsSignedType) { #>
-            (value: <#= x.EnumType #>.Zero,     name: nameof(<#= x.EnumType #>.Zero),     valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.Zero).ToString()),
+            (value: <#= x.EnumType #>.Zero,     name: nameof(<#= x.EnumType #>.Zero),     valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.Zero).ToString(CultureInfo.InvariantCulture)),
 <# } #>
-            (value: <#= x.EnumType #>.MaxValue, name: nameof(<#= x.EnumType #>.MaxValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MaxValue).ToString()),
+            (value: <#= x.EnumType #>.MaxValue, name: nameof(<#= x.EnumType #>.MaxValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.TryParse<<#= x.EnumType #>>(x.name, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(), out var _).Should().BeFalse();
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(), out var _).Should().BeFalse();
+                FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.valueString, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+                FastEnum.TryParse<<#= x.EnumType #>>(x.valueString, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.valueString.ToLower(), out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+                FastEnum.TryParse<<#= x.EnumType #>>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.valueString.ToUpper(), out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+                FastEnum.TryParse<<#= x.EnumType #>>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<<#= x.EnumType #>>((string?)null, out var _).Should().BeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>("123", out var r).Should().BeTrue();
+            r.Should().Be((<#= x.EnumType #>)123);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<<#= x.EnumType #>>(x, out var _).Should().BeFalse();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.TryParse<<#= x.EnumType #>>(nameUtf8, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
+
+                FastEnum.TryParse<<#= x.EnumType #>>(nameUtf8Lower, out var _).Should().BeFalse();
+                FastEnum.TryParse<<#= x.EnumType #>>(nameUtf8Upper, out var _).Should().BeFalse();
+
+                FastEnum.TryParse<<#= x.EnumType #>>(valueUtf8, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
+
+                FastEnum.TryParse<<#= x.EnumType #>>(valueUtf8Lower, out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
+
+                FastEnum.TryParse<<#= x.EnumType #>>(valueUtf8Upper, out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<<#= x.EnumType #>>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((<#= x.EnumType #>)123);
+        }
     }
 
 
@@ -317,34 +393,38 @@ public sealed class <#= x.AliasType #>Tests
     {
         var parameters = new[]
         {
-            (value: <#= x.EnumType #>.MinValue, name: nameof(<#= x.EnumType #>.MinValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MinValue).ToString()),
+            (value: <#= x.EnumType #>.MinValue, name: nameof(<#= x.EnumType #>.MinValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MinValue).ToString(CultureInfo.InvariantCulture)),
 <# if (x.IsSignedType) { #>
-            (value: <#= x.EnumType #>.Zero,     name: nameof(<#= x.EnumType #>.Zero),     valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.Zero).ToString()),
+            (value: <#= x.EnumType #>.Zero,     name: nameof(<#= x.EnumType #>.Zero),     valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.Zero).ToString(CultureInfo.InvariantCulture)),
 <# } #>
-            (value: <#= x.EnumType #>.MaxValue, name: nameof(<#= x.EnumType #>.MaxValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MaxValue).ToString()),
+            (value: <#= x.EnumType #>.MaxValue, name: nameof(<#= x.EnumType #>.MaxValue), valueString: ((<#= x.UnderlyingType #>)<#= x.EnumType #>.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
         foreach (var x in parameters)
         {
             FastEnum.TryParse<<#= x.EnumType #>>(x.name, true, out var r1).Should().BeTrue();
             r1.Should().Be(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(), true, out var r2).Should().BeTrue();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), true, out var r2).Should().BeTrue();
             r2.Should().Be(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(), true, out var r3).Should().BeTrue();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), true, out var r3).Should().BeTrue();
             r3.Should().Be(x.value);
 
             FastEnum.TryParse<<#= x.EnumType #>>(x.valueString, true, out var r4).Should().BeTrue();
             r4.Should().Be(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.valueString.ToLower(), true, out var r5).Should().BeTrue();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.valueString.ToLower(CultureInfo.InvariantCulture), true, out var r5).Should().BeTrue();
             r5.Should().Be(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.valueString.ToUpper(), true, out var r6).Should().BeTrue();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true, out var r6).Should().BeTrue();
             r6.Should().Be(x.value);
         }
-        foreach (var x in new[] { "ABCDE", "", null })
-            FastEnum.TryParse<<#= x.EnumType #>>(x, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>(" ", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((<#= x.EnumType #>)123);
     }
 
 

--- a/src/insights/FastEnum.UnitTests/Cases/EmptyTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/EmptyTests.cs
@@ -60,6 +60,7 @@ public class EmptyTests
     {
         FastEnum.IsDefined((TEnum)123).Should().BeFalse();
         FastEnum.IsDefined<TEnum>("123").Should().BeFalse();
+        FastEnum.IsDefined<TEnum>("123"u8).Should().BeFalse();
     }
 
 

--- a/src/insights/FastEnum.UnitTests/Cases/EmptyTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/EmptyTests.cs
@@ -69,6 +69,7 @@ public class EmptyTests
     {
         //--- Parse(ReadOnlySpan<char>)
         {
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>((string?)null)).Should().Throw<ArgumentException>();
             FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("")).Should().Throw<ArgumentException>();
             FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ")).Should().Throw<ArgumentException>();
             FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE")).Should().Throw<ArgumentException>();
@@ -88,9 +89,11 @@ public class EmptyTests
     [TestMethod]
     public void ParseIgnoreCase()
     {
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>((string?)null)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<TEnum>("123").Should().Be((TEnum)123);
     }
 
 
@@ -99,6 +102,7 @@ public class EmptyTests
     {
         //--- TryParse(ReadOnlySpan<char>)
         {
+            FastEnum.TryParse<TEnum>((string?)null, out var _).Should().BeFalse();
             FastEnum.TryParse<TEnum>("", out var _).Should().BeFalse();
             FastEnum.TryParse<TEnum>(" ", out var _).Should().BeFalse();
             FastEnum.TryParse<TEnum>("ABCDE", out var _).Should().BeFalse();
@@ -119,5 +123,12 @@ public class EmptyTests
 
     [TestMethod]
     public void TryParseIgnoreCase()
-        => FastEnum.TryParse<TEnum>("ABCDE", true, out var _).Should().BeFalse();
+    {
+        FastEnum.TryParse<TEnum>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>(" ", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((TEnum)123);
+    }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/EmptyTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/EmptyTests.cs
@@ -67,9 +67,21 @@ public class EmptyTests
     [TestMethod]
     public void Parse()
     {
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE")).Should().Throw<ArgumentException>();
+        //--- Parse(ReadOnlySpan<char>)
+        {
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<TEnum>("123").Should().Be((TEnum)123);
+        }
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<TEnum>("123"u8).Should().Be((TEnum)123);
+        }
     }
 
 
@@ -84,7 +96,25 @@ public class EmptyTests
 
     [TestMethod]
     public void TryParse()
-        => FastEnum.TryParse<TEnum>("ABCDE", out var _).Should().BeFalse();
+    {
+        //--- TryParse(ReadOnlySpan<char>)
+        {
+            FastEnum.TryParse<TEnum>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>("123", out var r).Should().BeTrue();
+            r.Should().Be((TEnum)123);
+        }
+
+        //--- TryParse(ReadOnlySpan<byte>)
+        {
+            FastEnum.TryParse<TEnum>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((TEnum)123);
+        }
+    }
 
 
     [TestMethod]

--- a/src/insights/FastEnum.UnitTests/Cases/SameValueTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/SameValueTests.cs
@@ -67,21 +67,25 @@ public class SameValueTests
     [TestMethod]
     public void IsDefined()
     {
+        //--- IsDefined(TEnum)
         FastEnum.IsDefined(TEnum.MinValue).Should().BeTrue();
         FastEnum.IsDefined(TEnum.Zero).Should().BeTrue();
         FastEnum.IsDefined(TEnum.MaxValue).Should().BeTrue();
         FastEnum.IsDefined((TEnum)123).Should().BeFalse();
 
+        //--- Extension methods
         TEnum.MinValue.IsDefined().Should().BeTrue();
         TEnum.Zero.IsDefined().Should().BeTrue();
         TEnum.MaxValue.IsDefined().Should().BeTrue();
 
+        //--- IsDefined(ReadOnlySpan<char>)
         FastEnum.IsDefined<TEnum>(nameof(TEnum.MinValue)).Should().BeTrue();
         FastEnum.IsDefined<TEnum>(nameof(TEnum.Zero)).Should().BeTrue();
         FastEnum.IsDefined<TEnum>(nameof(TEnum.MaxValue)).Should().BeTrue();
         FastEnum.IsDefined<TEnum>("123").Should().BeFalse();
         FastEnum.IsDefined<TEnum>("minvalue").Should().BeFalse();
 
+        //--- IsDefined(ReadOnlySpan<byte>)
         FastEnum.IsDefined<TEnum>("MinValue"u8).Should().BeTrue();
         FastEnum.IsDefined<TEnum>("Zero"u8).Should().BeTrue();
         FastEnum.IsDefined<TEnum>("MaxValue"u8).Should().BeTrue();

--- a/src/insights/FastEnum.UnitTests/Cases/SameValueTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/SameValueTests.cs
@@ -103,18 +103,49 @@ public class SameValueTests
             (value: TEnum.Zero,     name: nameof(TEnum.Zero),     valueString: ((TUnderlying)TEnum.Zero)    .ToString(CultureInfo.InvariantCulture)),
             (value: TEnum.MaxValue, name: nameof(TEnum.MaxValue), valueString: ((TUnderlying)TEnum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.Parse<TEnum>(x.name).Should().Be(x.value);
-            FastEnum.Parse<TEnum>(x.valueString).Should().Be(x.value);
-            FastEnum.Parse<TEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
-            FastEnum.Parse<TEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<TEnum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<TEnum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+            foreach (var x in parameters)
+            {
+                FastEnum.Parse<TEnum>(x.name).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<TEnum>(x.name.ToLower(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<TEnum>(x.name.ToUpper(CultureInfo.InvariantCulture))).Should().Throw<ArgumentException>();
+                FastEnum.Parse<TEnum>(x.valueString).Should().Be(x.value);
+                FastEnum.Parse<TEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture)).Should().Be(x.value);
+                FastEnum.Parse<TEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture)).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>((string?)null)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ")).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE")).Should().Throw<ArgumentException>();
+            FastEnum.Parse<TEnum>("123").Should().Be((TEnum)123);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(string.Empty)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ")).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE")).Should().Throw<ArgumentException>();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.Parse<TEnum>(nameUtf8).Should().Be(x.value);
+                FluentActions.Invoking(() => FastEnum.Parse<TEnum>(nameUtf8Lower)).Should().Throw<ArgumentException>();
+                FluentActions.Invoking(() => FastEnum.Parse<TEnum>(nameUtf8Upper)).Should().Throw<ArgumentException>();
+                FastEnum.Parse<TEnum>(valueUtf8).Should().Be(x.value);
+                FastEnum.Parse<TEnum>(valueUtf8Lower).Should().Be(x.value);
+                FastEnum.Parse<TEnum>(valueUtf8Upper).Should().Be(x.value);
+            }
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(""u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" "u8)).Should().Throw<ArgumentException>();
+            FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE"u8)).Should().Throw<ArgumentException>();
+            FastEnum.Parse<TEnum>("123"u8).Should().Be((TEnum)123);
+        }
     }
 
 
@@ -136,9 +167,11 @@ public class SameValueTests
             FastEnum.Parse<TEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture), true).Should().Be(x.value);
             FastEnum.Parse<TEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true).Should().Be(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(string.Empty, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>((string?)null, true)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ", true)).Should().Throw<ArgumentException>();
         FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE", true)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<TEnum>("123").Should().Be((TEnum)123);
     }
 
 
@@ -151,24 +184,67 @@ public class SameValueTests
             (value: TEnum.Zero,     name: nameof(TEnum.Zero),     valueString: ((TUnderlying)TEnum.Zero)    .ToString(CultureInfo.InvariantCulture)),
             (value: TEnum.MaxValue, name: nameof(TEnum.MaxValue), valueString: ((TUnderlying)TEnum.MaxValue).ToString(CultureInfo.InvariantCulture)),
         };
-        foreach (var x in parameters)
+
+        //--- Parse(ReadOnlySpan<char>)
         {
-            FastEnum.TryParse<TEnum>(x.name, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            foreach (var x in parameters)
+            {
+                FastEnum.TryParse<TEnum>(x.name, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
 
-            FastEnum.TryParse<TEnum>(x.valueString, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+                FastEnum.TryParse<TEnum>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<TEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
 
-            FastEnum.TryParse<TEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+                FastEnum.TryParse<TEnum>(x.valueString, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
 
-            FastEnum.TryParse<TEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+                FastEnum.TryParse<TEnum>(x.valueString.ToLower(CultureInfo.InvariantCulture), out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
 
-            FastEnum.TryParse<TEnum>(x.name.ToLower(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
-            FastEnum.TryParse<TEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), out var _).Should().BeFalse();
+                FastEnum.TryParse<TEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<TEnum>((string?)null, out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>("", out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>(" ", out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>("ABCDE", out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>("123", out var r).Should().BeTrue();
+            r.Should().Be((TEnum)123);
         }
-        FastEnum.TryParse<TEnum>("ABCDE", out var _).Should().BeFalse();
+
+        //--- Parse(ReadOnlySpan<byte>)
+        {
+            foreach (var x in parameters)
+            {
+                var nameUtf8 = Encoding.UTF8.GetBytes(x.name);
+                var nameUtf8Lower = Encoding.UTF8.GetBytes(x.name.ToLower(CultureInfo.InvariantCulture));
+                var nameUtf8Upper = Encoding.UTF8.GetBytes(x.name.ToUpper(CultureInfo.InvariantCulture));
+
+                var valueUtf8 = Encoding.UTF8.GetBytes(x.valueString);
+                var valueUtf8Lower = Encoding.UTF8.GetBytes(x.valueString.ToLower(CultureInfo.InvariantCulture));
+                var valueUtf8Upper = Encoding.UTF8.GetBytes(x.valueString.ToUpper(CultureInfo.InvariantCulture));
+
+                FastEnum.TryParse<TEnum>(nameUtf8, out var r1).Should().BeTrue();
+                r1.Should().Be(x.value);
+
+                FastEnum.TryParse<TEnum>(nameUtf8Lower, out var _).Should().BeFalse();
+                FastEnum.TryParse<TEnum>(nameUtf8Upper, out var _).Should().BeFalse();
+
+                FastEnum.TryParse<TEnum>(valueUtf8, out var r2).Should().BeTrue();
+                r2.Should().Be(x.value);
+
+                FastEnum.TryParse<TEnum>(valueUtf8Lower, out var r3).Should().BeTrue();
+                r3.Should().Be(x.value);
+
+                FastEnum.TryParse<TEnum>(valueUtf8Upper, out var r4).Should().BeTrue();
+                r4.Should().Be(x.value);
+            }
+            FastEnum.TryParse<TEnum>(""u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>(" "u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>("ABCDE"u8, out var _).Should().BeFalse();
+            FastEnum.TryParse<TEnum>("123"u8, out var r).Should().BeTrue();
+            r.Should().Be((TEnum)123);
+        }
     }
 
 
@@ -201,8 +277,12 @@ public class SameValueTests
             FastEnum.TryParse<TEnum>(x.valueString.ToUpper(CultureInfo.InvariantCulture), true, out var r6).Should().BeTrue();
             r6.Should().Be(x.value);
         }
-
+        FastEnum.TryParse<TEnum>((string?)null, true, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>(" ", true, out var _).Should().BeFalse();
         FastEnum.TryParse<TEnum>("ABCDE", true, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("123", true, out var r).Should().BeTrue();
+        r.Should().Be((TEnum)123);
     }
 
 

--- a/src/insights/FastEnum.UnitTests/Cases/SameValueTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/SameValueTests.cs
@@ -82,15 +82,11 @@ public class SameValueTests
         FastEnum.IsDefined<TEnum>("123").Should().BeFalse();
         FastEnum.IsDefined<TEnum>("minvalue").Should().BeFalse();
 
-        /*
-        FastEnum.IsDefined<TEnum>(TUnderlying.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<TEnum>(TUnderlying.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<TEnum>((TUnderlying)123).Should().BeFalse();
-        FluentActions
-            .Invoking(static () => FastEnum.IsDefined<TEnum>((sbyte)123))
-            .Should()
-            .Throw<ArgumentException>();
-        */
+        FastEnum.IsDefined<TEnum>("MinValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<TEnum>("Zero"u8).Should().BeTrue();
+        FastEnum.IsDefined<TEnum>("MaxValue"u8).Should().BeTrue();
+        FastEnum.IsDefined<TEnum>("123"u8).Should().BeFalse();
+        FastEnum.IsDefined<TEnum>("minvalue"u8).Should().BeFalse();
     }
 
 

--- a/src/libs/FastEnum.Core/FastEnum.Core.csproj
+++ b/src/libs/FastEnum.Core/FastEnum.Core.csproj
@@ -4,6 +4,10 @@
         <RootNamespace>FastEnumUtility</RootNamespace>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="System.IO.Hashing" />
+    </ItemGroup>
+
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
         <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>

--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -181,7 +181,7 @@ public static class FastEnum
     #endregion
 
 
-    #region Parse
+    #region Parse | ReadOnlySpan<char>
     /// <summary>
     /// Converts the string representation of the name or numeric value of one or more enumerated constants to an equivalent enumerated object.
     /// </summary>

--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -296,6 +296,63 @@ public static class FastEnum
     #endregion
 
 
+    #region Parse | ReadOnlySpan<byte>
+    /// <summary>
+    /// Converts the string representation of the UTF-8 name or numeric value of one or more enumerated constants to an equivalent enumerated object.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="ArgumentNullException"></exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T Parse<T>(ReadOnlySpan<byte> value)
+        where T : struct, Enum
+    {
+        if (!TryParse<T>(value, out var result))
+            ThrowHelper.ThrowValueNotDefined(nameof(value));
+        return result;
+    }
+
+
+    /// <summary>
+    /// Converts the string representation of the UTF-8 name or numeric value of one or more enumerated constants to an equivalent enumerated object.
+    /// The return value indicates whether the conversion succeeded.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="result"></param>
+    /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
+    /// <returns>true if the value parameter was converted successfully; otherwise, false.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryParse<T>(ReadOnlySpan<byte> value, out T result)
+        where T : struct, Enum
+    {
+        if (value.IsEmpty)
+        {
+            result = default;
+            return false;
+        }
+
+        return tryParseNameCaseSensitive(value, out result);
+
+
+        #region Local Functions
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static bool tryParseNameCaseSensitive(ReadOnlySpan<byte> name, out T result)
+        {
+            if (EnumInfo<T>.s_memberByNameUtf8CaseSensitive.TryGetValue(name, out var member))
+            {
+                result = member.Value;
+                return true;
+            }
+            result = default;
+            return false;
+        }
+        #endregion
+    }
+    #endregion
+
+
     #region ToString
     /// <summary>
     /// Converts the specified value to its equivalent string representation.

--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -147,6 +147,18 @@ public static class FastEnum
 
 
     /// <summary>
+    /// Returns an indication whether a constant with a specified UTF-8 name exists in a specified enumeration.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsDefined<T>(ReadOnlySpan<byte> name)
+        where T : struct, Enum
+        => EnumInfo<T>.s_memberByNameUtf8CaseSensitive.ContainsKey(name);
+
+
+    /// <summary>
     /// Returns whether no fields in a specified enumeration.
     /// </summary>
     /// <typeparam name="T"><see cref="Enum"/> type</typeparam>

--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -110,7 +110,7 @@ public static class FastEnum
     #endregion
 
 
-    #region Condition
+    #region IsXxx
     /// <summary>
     /// Returns whether the values of the constants in a specified enumeration are continuous.
     /// </summary>

--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -123,42 +123,6 @@ public static class FastEnum
 
 
     /// <summary>
-    /// Returns an indication whether a constant with a specified value exists in a specified enumeration.
-    /// </summary>
-    /// <param name="value"></param>
-    /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsDefined<T>(T value)
-        where T : struct, Enum
-        => UnderlyingOperation<T>.IsDefined(value);
-
-
-    /// <summary>
-    /// Returns an indication whether a constant with a specified name exists in a specified enumeration.
-    /// </summary>
-    /// <param name="name"></param>
-    /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsDefined<T>(ReadOnlySpan<char> name)
-        where T : struct, Enum
-        => EnumInfo<T>.s_memberByNameCaseSensitive.ContainsKey(name);
-
-
-    /// <summary>
-    /// Returns an indication whether a constant with a specified UTF-8 name exists in a specified enumeration.
-    /// </summary>
-    /// <param name="name"></param>
-    /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsDefined<T>(ReadOnlySpan<byte> name)
-        where T : struct, Enum
-        => EnumInfo<T>.s_memberByNameUtf8CaseSensitive.ContainsKey(name);
-
-
-    /// <summary>
     /// Returns whether no fields in a specified enumeration.
     /// </summary>
     /// <typeparam name="T"><see cref="Enum"/> type</typeparam>

--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -145,6 +145,44 @@ public static class FastEnum
     #endregion
 
 
+    #region IsDefined
+    /// <summary>
+    /// Returns an indication whether a constant with a specified value exists in a specified enumeration.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsDefined<T>(T value)
+        where T : struct, Enum
+        => UnderlyingOperation<T>.IsDefined(value);
+
+
+    /// <summary>
+    /// Returns an indication whether a constant with a specified name exists in a specified enumeration.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsDefined<T>(ReadOnlySpan<char> name)
+        where T : struct, Enum
+        => EnumInfo<T>.s_memberByNameCaseSensitive.ContainsKey(name);
+
+
+    /// <summary>
+    /// Returns an indication whether a constant with a specified UTF-8 name exists in a specified enumeration.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <typeparam name="T"><see cref="Enum"/> type</typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsDefined<T>(ReadOnlySpan<byte> name)
+        where T : struct, Enum
+        => EnumInfo<T>.s_memberByNameUtf8CaseSensitive.ContainsKey(name);
+    #endregion
+
+
     #region Parse | ReadOnlySpan<char>
     /// <summary>
     /// Converts the string representation of the name or numeric value of one or more enumerated constants to an equivalent enumerated object.

--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -333,10 +333,38 @@ public static class FastEnum
             return false;
         }
 
+        if (isNumeric(value.At(0)))
+            return UnderlyingOperation<T>.TryParseValue(value, out result);
+
         return tryParseNameCaseSensitive(value, out result);
 
 
         #region Local Functions
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static bool isNumeric(byte x)
+        {
+            // note:
+            //  - In this case, there is no change in speed with or without sequential numbering.
+
+            return x switch
+            {
+                (byte)'+' => true,  // 43
+                (byte)'-' => true,  // 45
+                (byte)'0' => true,  // 48
+                (byte)'1' => true,
+                (byte)'2' => true,
+                (byte)'3' => true,
+                (byte)'4' => true,
+                (byte)'5' => true,
+                (byte)'6' => true,
+                (byte)'7' => true,
+                (byte)'8' => true,
+                (byte)'9' => true,
+                _ => false,
+            };
+        }
+
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool tryParseNameCaseSensitive(ReadOnlySpan<byte> name, out T result)
         {

--- a/src/libs/FastEnum.Core/Internals/CollectionExtensions.cs
+++ b/src/libs/FastEnum.Core/Internals/CollectionExtensions.cs
@@ -65,4 +65,14 @@ internal static class CollectionExtensions
     public static CaseInsensitiveStringDictionary<TValue> ToCaseInsensitiveStringDictionary<TSource, TValue>(this IEnumerable<TSource> source, Func<TSource, string> keySelector, Func<TSource, TValue> valueSelector)
         => CaseInsensitiveStringDictionary<TValue>.Create(source, keySelector, valueSelector);
     #endregion
+
+
+    #region CaseSensitiveUtf8StringDictionary
+    public static CaseSensitiveUtf8StringDictionary<TValue> ToCaseSensitiveUtf8StringDictionary<TValue>(this IEnumerable<TValue> source, Func<TValue, byte[]> keySelector)
+        => CaseSensitiveUtf8StringDictionary<TValue>.Create(source, keySelector, static x => x);
+
+
+    public static CaseSensitiveUtf8StringDictionary<TValue> ToCaseSensitiveUtf8StringDictionary<TSource, TValue>(this IEnumerable<TSource> source, Func<TSource, byte[]> keySelector, Func<TSource, TValue> valueSelector)
+        => CaseSensitiveUtf8StringDictionary<TValue>.Create(source, keySelector, valueSelector);
+    #endregion
 }

--- a/src/libs/FastEnum.Core/Internals/EnumInfo.cs
+++ b/src/libs/FastEnum.Core/Internals/EnumInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace FastEnumUtility.Internals;
 
@@ -23,6 +24,7 @@ internal static class EnumInfo<T>
     public static readonly Member<T>[] s_orderedMembers;
     public static readonly CaseSensitiveStringDictionary<Member<T>> s_memberByNameCaseSensitive;
     public static readonly CaseInsensitiveStringDictionary<Member<T>> s_memberByNameCaseInsensitive;
+    public static readonly CaseSensitiveUtf8StringDictionary<Member<T>> s_memberByNameUtf8CaseSensitive;
     public static readonly FastReadOnlyDictionary<T, Member<T>> s_memberByValue;
     public static readonly T s_minValue;
     public static readonly T s_maxValue;
@@ -44,6 +46,7 @@ internal static class EnumInfo<T>
         s_orderedMembers = s_members.OrderBy(static x => x.Value).ToArray();
         s_memberByNameCaseSensitive = s_members.ToCaseSensitiveStringDictionary(static x => x.Name);
         s_memberByNameCaseInsensitive = s_members.ToCaseInsensitiveStringDictionary(static x => x.Name);
+        s_memberByNameUtf8CaseSensitive = s_members.ToCaseSensitiveUtf8StringDictionary(static x => ImmutableCollectionsMarshal.AsArray(x.NameUtf8) ?? []);
         s_memberByValue
             = s_orderedMembers
             .DistinctBy(static x => x.Value)

--- a/src/libs/FastEnum.Core/Internals/StringHelper.cs
+++ b/src/libs/FastEnum.Core/Internals/StringHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 
 namespace FastEnumUtility.Internals;
@@ -52,4 +53,24 @@ internal static class CaseInsensitiveStringHelper
     [UnsafeAccessor(UnsafeAccessorKind.StaticMethod)]
     private static extern int GetHashCodeOrdinalIgnoreCase(string? self, ReadOnlySpan<char> value);
 #endif
+}
+
+
+
+internal static class CaseSensitiveUtf8StringHelpers
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetHashCode(ReadOnlySpan<byte> value)
+    {
+        // note:
+        //  - The return value is ulong because it is calculated in 64 bits.
+        //  - But if a 32-bit value is needed, simply truncate the value.
+
+        return unchecked((int)XxHash3.HashToUInt64(value));
+    }
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool Equals(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y)
+        => MemoryExtensions.SequenceEqual(x, y);
 }

--- a/src/libs/FastEnum.Core/Internals/ThrowHelper.cs
+++ b/src/libs/FastEnum.Core/Internals/ThrowHelper.cs
@@ -33,6 +33,14 @@ internal static class ThrowHelper
 
 
     [DoesNotReturn]
+    public static void ThrowValueNotDefined(string? paramName)
+    {
+        const string message = "Specified value is not defined.";
+        throw new ArgumentException(message, paramName);
+    }
+
+
+    [DoesNotReturn]
     public static void ThrowLabelNotFound(int index)
     {
         var message = $"{nameof(LabelAttribute)} that is specified index {index} is not found.";

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
@@ -237,11 +237,7 @@ internal static class UnderlyingOperation<T>
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, sbyte>(ref result);
-#if NET8_0_OR_GREATER
             return sbyte.TryParse(text, CultureInfo.InvariantCulture, out x);
-#else
-            return sbyte.TryParse(text, out x);
-#endif
         }
 
 
@@ -347,11 +343,7 @@ internal static class UnderlyingOperation<T>
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, byte>(ref result);
-#if NET8_0_OR_GREATER
             return byte.TryParse(text, CultureInfo.InvariantCulture, out x);
-#else
-            return byte.TryParse(text, out x);
-#endif
         }
 
 
@@ -457,11 +449,7 @@ internal static class UnderlyingOperation<T>
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, short>(ref result);
-#if NET8_0_OR_GREATER
             return short.TryParse(text, CultureInfo.InvariantCulture, out x);
-#else
-            return short.TryParse(text, out x);
-#endif
         }
 
 
@@ -567,11 +555,7 @@ internal static class UnderlyingOperation<T>
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, ushort>(ref result);
-#if NET8_0_OR_GREATER
             return ushort.TryParse(text, CultureInfo.InvariantCulture, out x);
-#else
-            return ushort.TryParse(text, out x);
-#endif
         }
 
 
@@ -677,11 +661,7 @@ internal static class UnderlyingOperation<T>
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, int>(ref result);
-#if NET8_0_OR_GREATER
             return int.TryParse(text, CultureInfo.InvariantCulture, out x);
-#else
-            return int.TryParse(text, out x);
-#endif
         }
 
 
@@ -787,11 +767,7 @@ internal static class UnderlyingOperation<T>
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, uint>(ref result);
-#if NET8_0_OR_GREATER
             return uint.TryParse(text, CultureInfo.InvariantCulture, out x);
-#else
-            return uint.TryParse(text, out x);
-#endif
         }
 
 
@@ -897,11 +873,7 @@ internal static class UnderlyingOperation<T>
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, long>(ref result);
-#if NET8_0_OR_GREATER
             return long.TryParse(text, CultureInfo.InvariantCulture, out x);
-#else
-            return long.TryParse(text, out x);
-#endif
         }
 
 
@@ -1007,11 +979,7 @@ internal static class UnderlyingOperation<T>
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, ulong>(ref result);
-#if NET8_0_OR_GREATER
             return ulong.TryParse(text, CultureInfo.InvariantCulture, out x);
-#else
-            return ulong.TryParse(text, out x);
-#endif
         }
 
 

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
@@ -118,6 +118,34 @@ internal static class UnderlyingOperation<T>
 
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
+    {
+        switch (EnumInfo<T>.s_typeCode)
+        {
+            case TypeCode.SByte:
+                return SByteOperation.TryParseValue(text, out result);
+            case TypeCode.Byte:
+                return ByteOperation.TryParseValue(text, out result);
+            case TypeCode.Int16:
+                return Int16Operation.TryParseValue(text, out result);
+            case TypeCode.UInt16:
+                return UInt16Operation.TryParseValue(text, out result);
+            case TypeCode.Int32:
+                return Int32Operation.TryParseValue(text, out result);
+            case TypeCode.UInt32:
+                return UInt32Operation.TryParseValue(text, out result);
+            case TypeCode.Int64:
+                return Int64Operation.TryParseValue(text, out result);
+            case TypeCode.UInt64:
+                return UInt64Operation.TryParseValue(text, out result);
+            default:
+                result = default;
+                return false;
+        }
+    }
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetMember(T value, [NotNullWhen(true)] out Member<T>? result)
     {
         switch (EnumInfo<T>.s_typeCode)
@@ -197,6 +225,19 @@ internal static class UnderlyingOperation<T>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
+        {
+            Unsafe.SkipInit(out result);
+            ref var x = ref Unsafe.As<T, sbyte>(ref result);
+#if NET8_0_OR_GREATER
+            return sbyte.TryParse(text, CultureInfo.InvariantCulture, out x);
+#else
+            return sbyte.TryParse(text, out x);
+#endif
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, sbyte>(ref result);
@@ -310,6 +351,19 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
+        {
+            Unsafe.SkipInit(out result);
+            ref var x = ref Unsafe.As<T, byte>(ref result);
+#if NET8_0_OR_GREATER
+            return byte.TryParse(text, CultureInfo.InvariantCulture, out x);
+#else
+            return byte.TryParse(text, out x);
+#endif
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryGetMember(T value, [NotNullWhen(true)] out Member<T>? result)
         {
             if (EnumInfo<T>.s_isContinuous)
@@ -399,6 +453,19 @@ internal static class UnderlyingOperation<T>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
+        {
+            Unsafe.SkipInit(out result);
+            ref var x = ref Unsafe.As<T, short>(ref result);
+#if NET8_0_OR_GREATER
+            return short.TryParse(text, CultureInfo.InvariantCulture, out x);
+#else
+            return short.TryParse(text, out x);
+#endif
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, short>(ref result);
@@ -512,6 +579,19 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
+        {
+            Unsafe.SkipInit(out result);
+            ref var x = ref Unsafe.As<T, ushort>(ref result);
+#if NET8_0_OR_GREATER
+            return ushort.TryParse(text, CultureInfo.InvariantCulture, out x);
+#else
+            return ushort.TryParse(text, out x);
+#endif
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryGetMember(T value, [NotNullWhen(true)] out Member<T>? result)
         {
             if (EnumInfo<T>.s_isContinuous)
@@ -601,6 +681,19 @@ internal static class UnderlyingOperation<T>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
+        {
+            Unsafe.SkipInit(out result);
+            ref var x = ref Unsafe.As<T, int>(ref result);
+#if NET8_0_OR_GREATER
+            return int.TryParse(text, CultureInfo.InvariantCulture, out x);
+#else
+            return int.TryParse(text, out x);
+#endif
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, int>(ref result);
@@ -714,6 +807,19 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
+        {
+            Unsafe.SkipInit(out result);
+            ref var x = ref Unsafe.As<T, uint>(ref result);
+#if NET8_0_OR_GREATER
+            return uint.TryParse(text, CultureInfo.InvariantCulture, out x);
+#else
+            return uint.TryParse(text, out x);
+#endif
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryGetMember(T value, [NotNullWhen(true)] out Member<T>? result)
         {
             if (EnumInfo<T>.s_isContinuous)
@@ -815,6 +921,19 @@ internal static class UnderlyingOperation<T>
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
+        {
+            Unsafe.SkipInit(out result);
+            ref var x = ref Unsafe.As<T, long>(ref result);
+#if NET8_0_OR_GREATER
+            return long.TryParse(text, CultureInfo.InvariantCulture, out x);
+#else
+            return long.TryParse(text, out x);
+#endif
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryGetMember(T value, [NotNullWhen(true)] out Member<T>? result)
         {
             if (EnumInfo<T>.s_isContinuous)
@@ -904,6 +1023,19 @@ internal static class UnderlyingOperation<T>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
+        {
+            Unsafe.SkipInit(out result);
+            ref var x = ref Unsafe.As<T, ulong>(ref result);
+#if NET8_0_OR_GREATER
+            return ulong.TryParse(text, CultureInfo.InvariantCulture, out x);
+#else
+            return ulong.TryParse(text, out x);
+#endif
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, ulong>(ref result);

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
@@ -191,11 +191,7 @@ internal static class UnderlyingOperation<T>
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, <#= x.CompatibleName #>>(ref result);
-#if NET8_0_OR_GREATER
             return <#= x.CompatibleName #>.TryParse(text, CultureInfo.InvariantCulture, out x);
-#else
-            return <#= x.CompatibleName #>.TryParse(text, out x);
-#endif
         }
 
 

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
@@ -95,6 +95,22 @@ internal static class UnderlyingOperation<T>
 
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
+    {
+        switch (EnumInfo<T>.s_typeCode)
+        {
+<# foreach (var x in parameters) { #>
+            case TypeCode.<#= x.TypeName #>:
+                return <#= x.TypeName #>Operation.TryParseValue(text, out result);
+<# } #>
+            default:
+                result = default;
+                return false;
+        }
+    }
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetMember(T value, [NotNullWhen(true)] out Member<T>? result)
     {
         switch (EnumInfo<T>.s_typeCode)
@@ -163,6 +179,19 @@ internal static class UnderlyingOperation<T>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParseValue(ReadOnlySpan<char> text, out T result)
+        {
+            Unsafe.SkipInit(out result);
+            ref var x = ref Unsafe.As<T, <#= x.CompatibleName #>>(ref result);
+#if NET8_0_OR_GREATER
+            return <#= x.CompatibleName #>.TryParse(text, CultureInfo.InvariantCulture, out x);
+#else
+            return <#= x.CompatibleName #>.TryParse(text, out x);
+#endif
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseValue(ReadOnlySpan<byte> text, out T result)
         {
             Unsafe.SkipInit(out result);
             ref var x = ref Unsafe.As<T, <#= x.CompatibleName #>>(ref result);


### PR DESCRIPTION
# Summary
`ReadOnlySpan<byte>` (= UTF-8 byte sequence) is newly supported for the following methods.

- `.IsDefined<T>(ReadOnlySpan<byte> text)`
- `.Parse<T>(ReadOnlySpan<byte> text)`
- `.TryParse<T>(ReadOnlySpan<byte> text, out T result)`