### PR TITLE
Speed up numeric check

### DIFF
--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -263,8 +263,28 @@ public static class FastEnum
 
         #region Local Functions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool isNumeric(char c)
-            => char.IsAsciiDigit(c) || (c is '-' or '+');
+        static bool isNumeric(char x)
+        {
+            // note:
+            //  - In this case, there is no change in speed with or without sequential numbering.
+
+            return x switch
+            {
+                '+' => true,  // 43
+                '-' => true,  // 45
+                '0' => true,  // 48
+                '1' => true,
+                '2' => true,
+                '3' => true,
+                '4' => true,
+                '5' => true,
+                '6' => true,
+                '7' => true,
+                '8' => true,
+                '9' => true,
+                _ => false,
+            };
+        }
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
# Summary
`switch` is faster than judgment by range check.

# Benchmark
![image](https://github.com/user-attachments/assets/02c9d38c-80d1-47a6-8aff-2ed3fae6a093)
