### PR TITLE
Downgrade the referenced version of Microsoft.CodeAnalysis.CSharp to 4.4.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Enums.NET" Version="5.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageVersion Include="MSTest" Version="3.6.0" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta09" />
   </ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Enums.NET" Version="5.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageVersion Include="MSTest" Version="3.6.0" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta09" />
   </ItemGroup>

--- a/src/libs/FastEnum.Generators/FastEnumBoosterGenerator.cs
+++ b/src/libs/FastEnum.Generators/FastEnumBoosterGenerator.cs
@@ -415,7 +415,13 @@ public sealed class FastEnumBoosterGenerator : IIncrementalGenerator
             this.TypeName = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
             this.UnderlyingType = symbol.EnumUnderlyingType?.ToDisplayString() ?? "int";
             this.Fields = symbol.GetMembers().OfType<IFieldSymbol>().ToArray();
+#pragma warning disable RS1024  // Use 'SymbolEqualityComparer' when comparing symbols
+            // note:
+            //  - In this case, where a custom IEqualityComparer<T> is being utilized, the RS1024 warning is deemed inappropriate and is recognized as a bug in Microsoft.CodeAnalysis.CSharp.
+            //  - Although this issue has been rectified in version 4.6.0, the use of version 4.4.0 does not present any functional problems.
+            //  - Consequently, we have opted to address this by suppressing the warning.
             this.DistinctedFields = this.Fields.Distinct(new FieldSymbolComparer()).ToArray();
+#pragma warning restore RS1024
 
 
             #region Local Functions


### PR DESCRIPTION
# Summary
We will reduce the package reference for `Microsoft.CodeAnalysis.CSharp` to the minimum version that can maintain functionality. This will minimize potential interference with other Source Generator libraries to the greatest extent possible. We anticipate that this may mitigate #46.