### PR TITLE
Fix the oversight regarding the attribute of full qualified name.

### DIFF
--- a/src/insights/FastEnum.Sandbox/Program.cs
+++ b/src/insights/FastEnum.Sandbox/Program.cs
@@ -23,7 +23,7 @@ namespace FastEnumUtility.Sandbox
     //{ }
 
 
-    [FastEnum<HttpStatusCode>]
+    [global::FastEnumUtility.FastEnum<HttpStatusCode>]
     public partial class HttpStatusCodeBooster
     { }
 }

--- a/src/insights/FastEnum.UnitTests/Models/Boosters.cs
+++ b/src/insights/FastEnum.UnitTests/Models/Boosters.cs
@@ -50,12 +50,12 @@ public sealed partial class UInt64EnumBooster
 
 
 
-[FastEnum<SameValueEnum>]
+[FastEnumUtility.FastEnum<SameValueEnum>]  // full qualified name syntax
 public sealed partial class SameValueEnumBooster
 { }
 
 
 
-[FastEnum<EmptyEnum>]
+[global::FastEnumUtility.FastEnum<EmptyEnum>]  // full qualified name syntax
 public sealed partial class EmptyEnumBooster
 { }

--- a/src/libs/FastEnum.Generators/FastEnumBoosterGenerator.cs
+++ b/src/libs/FastEnum.Generators/FastEnumBoosterGenerator.cs
@@ -319,7 +319,8 @@ public sealed class FastEnumBoosterGenerator : IIncrementalGenerator
                 var attributes = syntax.AttributeLists.SelectMany(static x => x.Attributes);
                 foreach (var attr in attributes)
                 {
-                    if (attr.Name is not GenericNameSyntax generic)
+                    var generic = getGenericNameSyntax(attr.Name);
+                    if (generic is null)
                         continue;
 
                     if (generic.Identifier.Text is not ("FastEnum" or "FastEnumAttribute"))
@@ -329,6 +330,18 @@ public sealed class FastEnumBoosterGenerator : IIncrementalGenerator
                     return @enum;
                 }
                 throw new InvalidOperationException("FastEnumAttribute<T> is not annotated.");
+            }
+
+
+            static GenericNameSyntax? getGenericNameSyntax(NameSyntax syntax)
+            {
+                if (syntax is QualifiedNameSyntax qualified)  // [global::FastEnumUtility.FastEnum<TEnum>]
+                    return getGenericNameSyntax(qualified.Right);
+
+                if (syntax is GenericNameSyntax generic)  // [FastEnum<TEnum>]
+                    return generic;
+
+                return null;
             }
 
 


### PR DESCRIPTION
# Summary
We will fix the oversight regarding the annotation of attributes with the fully qualified name.

```cs
[FastEnum<HttpStatusCode>]  // OK
public partial class HttpStatusCodeBooster
{}
```
```cs
[global::FastEnumUtility.FastEnum<HttpStatusCode>]  // NG
public partial class HttpStatusCodeBooster
{}
```