### PR TITLE
Fix `.GetName()` method inconsistency for enums with duplicate values

### DIFF
--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/ContinuousValueTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/ContinuousValueTests.cs
@@ -36,7 +36,7 @@ public class ContinuousValueTests
         FastEnum.GetName(ContinuousValueContainsSameValueEnum.A).Should().Be(nameof(ContinuousValueContainsSameValueEnum.A));
         FastEnum.GetName(ContinuousValueContainsSameValueEnum.B).Should().Be(nameof(ContinuousValueContainsSameValueEnum.B));
         FastEnum.GetName(ContinuousValueContainsSameValueEnum.C).Should().Be(nameof(ContinuousValueContainsSameValueEnum.C));
-        FastEnum.GetName(ContinuousValueContainsSameValueEnum.D).Should().Be(nameof(ContinuousValueContainsSameValueEnum.D));
+        FastEnum.GetName(ContinuousValueContainsSameValueEnum.D).Should().Be(nameof(ContinuousValueContainsSameValueEnum.C));  // should be same as C
         FastEnum.GetName(ContinuousValueContainsSameValueEnum.E).Should().Be(nameof(ContinuousValueContainsSameValueEnum.E));
 
         FastEnum.GetName(NotContinuousValueEnum.A).Should().Be(nameof(NotContinuousValueEnum.A));

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/ContinuousValueTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/ContinuousValueTests.cs
@@ -32,5 +32,17 @@ public class ContinuousValueTests
         FastEnum.GetName(ContinuousValueEnum.C).Should().Be(nameof(ContinuousValueEnum.C));
         FastEnum.GetName(ContinuousValueEnum.D).Should().Be(nameof(ContinuousValueEnum.D));
         FastEnum.GetName(ContinuousValueEnum.E).Should().Be(nameof(ContinuousValueEnum.E));
+
+        FastEnum.GetName(ContinuousValueContainsSameValueEnum.A).Should().Be(nameof(ContinuousValueContainsSameValueEnum.A));
+        FastEnum.GetName(ContinuousValueContainsSameValueEnum.B).Should().Be(nameof(ContinuousValueContainsSameValueEnum.B));
+        FastEnum.GetName(ContinuousValueContainsSameValueEnum.C).Should().Be(nameof(ContinuousValueContainsSameValueEnum.C));
+        FastEnum.GetName(ContinuousValueContainsSameValueEnum.D).Should().Be(nameof(ContinuousValueContainsSameValueEnum.D));
+        FastEnum.GetName(ContinuousValueContainsSameValueEnum.E).Should().Be(nameof(ContinuousValueContainsSameValueEnum.E));
+
+        FastEnum.GetName(NotContinuousValueEnum.A).Should().Be(nameof(NotContinuousValueEnum.A));
+        FastEnum.GetName(NotContinuousValueEnum.B).Should().Be(nameof(NotContinuousValueEnum.B));
+        FastEnum.GetName(NotContinuousValueEnum.C).Should().Be(nameof(NotContinuousValueEnum.C));
+        FastEnum.GetName(NotContinuousValueEnum.D).Should().Be(nameof(NotContinuousValueEnum.D));
+        FastEnum.GetName(NotContinuousValueEnum.E).Should().Be(nameof(NotContinuousValueEnum.E));
     }
 }

--- a/src/libs/FastEnum.Core/Internals/EnumInfo.cs
+++ b/src/libs/FastEnum.Core/Internals/EnumInfo.cs
@@ -41,13 +41,14 @@ internal static class EnumInfo<T>
         s_names = Enum.GetNames(s_type);
         s_values = (T[])Enum.GetValues(s_type);
         s_members = s_names.Select(static x => new Member<T>(x)).ToArray();
-        s_orderedMembers = s_members.OrderBy(static x => x.Value).ToArray();
+        s_orderedMembers
+            = s_members
+            .OrderBy(static x => x.Value)
+            .DistinctBy(static x => x.Value)
+            .ToArray();
         s_memberByNameCaseSensitive = s_members.ToCaseSensitiveStringDictionary(static x => x.Name);
         s_memberByNameCaseInsensitive = s_members.ToCaseInsensitiveStringDictionary(static x => x.Name);
-        s_memberByValue
-            = s_orderedMembers
-            .DistinctBy(static x => x.Value)
-            .ToFastReadOnlyDictionary(static x => x.Value);
+        s_memberByValue = s_orderedMembers.ToFastReadOnlyDictionary(static x => x.Value);
         s_minValue = s_values.DefaultIfEmpty().Min();
         s_maxValue = s_values.DefaultIfEmpty().Max();
         s_isContinuous = isContinuous(s_memberByValue.Count, s_maxValue, s_minValue);


### PR DESCRIPTION
# Summary
Fixes an issue where executing the `.GetName()` method on an enum type containing duplicate values may return a value different from the expected one.

# Related issues
- #54 