### PR TITLE
Safeguard for case-insensitive dictionary generation

### DIFF
--- a/src/insights/FastEnum.UnitTests/Cases/Generators/CaseInsensitiveTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Generators/CaseInsensitiveTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Globalization;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TBooster = FastEnumUtility.UnitTests.Models.CaseInsensitiveEnumBooster;
+using TEnum = FastEnumUtility.UnitTests.Models.CaseInsensitiveEnum;
+
+namespace FastEnumUtility.UnitTests.Cases.Generators;
+
+
+
+[TestClass]
+public class CaseInsensitiveTests
+{
+    [TestMethod]
+    public void Parse()
+    {
+        const bool ignoreCase = false;
+        var parameters = new[]
+        {
+            (value: TEnum.A, name: nameof(TEnum.A)),
+            (value: TEnum.a, name: nameof(TEnum.a)),
+            (value: TEnum.b, name: nameof(TEnum.b)),
+            (value: TEnum.B, name: nameof(TEnum.B)),
+            (value: TEnum.C, name: nameof(TEnum.C)),
+        };
+        foreach (var x in parameters)
+        {
+            var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
+            FastEnum.Parse<TEnum, TBooster>(x.name, ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<TEnum, TBooster>(valueString, ignoreCase).Should().Be(x.value);
+        }
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<TEnum, TBooster>("123", ignoreCase).Should().Be((TEnum)123);
+    }
+
+
+    [TestMethod]
+    public void ParseIgnoreCase()
+    {
+        const bool ignoreCase = true;
+        var parameters = new[]
+        {
+            (value: TEnum.A, name: nameof(TEnum.A)),
+            (value: TEnum.A, name: nameof(TEnum.a)),
+            (value: TEnum.b, name: nameof(TEnum.b)),
+            (value: TEnum.b, name: nameof(TEnum.B)),
+            (value: TEnum.C, name: nameof(TEnum.C)),
+        };
+        foreach (var x in parameters)
+        {
+            var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
+            FastEnum.Parse<TEnum, TBooster>(x.name, ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<TEnum, TBooster>(valueString, ignoreCase).Should().Be(x.value);
+        }
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<TEnum, TBooster>("123", ignoreCase).Should().Be((TEnum)123);
+    }
+
+
+    [TestMethod]
+    public void TryParse()
+    {
+        const bool ignoreCase = false;
+        var parameters = new[]
+        {
+            (value: TEnum.A, name: nameof(TEnum.A)),
+            (value: TEnum.a, name: nameof(TEnum.a)),
+            (value: TEnum.b, name: nameof(TEnum.b)),
+            (value: TEnum.B, name: nameof(TEnum.B)),
+            (value: TEnum.C, name: nameof(TEnum.C)),
+        };
+        foreach (var x in parameters)
+        {
+            FastEnum.TryParse<TEnum, TBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
+            r1.Should().Be(x.value);
+
+            var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
+            FastEnum.TryParse<TEnum, TBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
+            r2.Should().Be(x.value);
+        }
+        FastEnum.TryParse<TEnum, TBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum, TBooster>(" ", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("123", ignoreCase, out var r).Should().BeTrue();
+        r.Should().Be((TEnum)123);
+    }
+
+
+    [TestMethod]
+    public void TryParseIgnoreCase()
+    {
+        const bool ignoreCase = true;
+        var parameters = new[]
+        {
+            (value: TEnum.A, name: nameof(TEnum.A)),
+            (value: TEnum.A, name: nameof(TEnum.a)),
+            (value: TEnum.b, name: nameof(TEnum.b)),
+            (value: TEnum.b, name: nameof(TEnum.B)),
+            (value: TEnum.C, name: nameof(TEnum.C)),
+        };
+        foreach (var x in parameters)
+        {
+            FastEnum.TryParse<TEnum, TBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
+            r1.Should().Be(x.value);
+
+            var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
+            FastEnum.TryParse<TEnum, TBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
+            r2.Should().Be(x.value);
+        }
+        FastEnum.TryParse<TEnum, TBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum, TBooster>(" ", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("123", ignoreCase, out var r).Should().BeTrue();
+        r.Should().Be((TEnum)123);
+    }
+}

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/CaseInsensitiveTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/CaseInsensitiveTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Globalization;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TEnum = FastEnumUtility.UnitTests.Models.CaseInsensitiveEnum;
+
+namespace FastEnumUtility.UnitTests.Cases.Reflections;
+
+
+
+[TestClass]
+public class CaseInsensitiveTests
+{
+    [TestMethod]
+    public void Parse()
+    {
+        const bool ignoreCase = false;
+        var parameters = new[]
+        {
+            (value: TEnum.A, name: nameof(TEnum.A)),
+            (value: TEnum.a, name: nameof(TEnum.a)),
+            (value: TEnum.b, name: nameof(TEnum.b)),
+            (value: TEnum.B, name: nameof(TEnum.B)),
+            (value: TEnum.C, name: nameof(TEnum.C)),
+        };
+        foreach (var x in parameters)
+        {
+            var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
+            FastEnum.Parse<TEnum>(x.name, ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<TEnum>(valueString, ignoreCase).Should().Be(x.value);
+        }
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<TEnum>("123", ignoreCase).Should().Be((TEnum)123);
+    }
+
+
+    [TestMethod]
+    public void ParseIgnoreCase()
+    {
+        const bool ignoreCase = true;
+        var parameters = new[]
+        {
+            (value: TEnum.A, name: nameof(TEnum.A)),
+            (value: TEnum.A, name: nameof(TEnum.a)),
+            (value: TEnum.b, name: nameof(TEnum.b)),
+            (value: TEnum.b, name: nameof(TEnum.B)),
+            (value: TEnum.C, name: nameof(TEnum.C)),
+        };
+        foreach (var x in parameters)
+        {
+            var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
+            FastEnum.Parse<TEnum>(x.name, ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<TEnum>(valueString, ignoreCase).Should().Be(x.value);
+        }
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
+        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
+        FastEnum.Parse<TEnum>("123", ignoreCase).Should().Be((TEnum)123);
+    }
+
+
+    [TestMethod]
+    public void TryParse()
+    {
+        const bool ignoreCase = false;
+        var parameters = new[]
+        {
+            (value: TEnum.A, name: nameof(TEnum.A)),
+            (value: TEnum.a, name: nameof(TEnum.a)),
+            (value: TEnum.b, name: nameof(TEnum.b)),
+            (value: TEnum.B, name: nameof(TEnum.B)),
+            (value: TEnum.C, name: nameof(TEnum.C)),
+        };
+        foreach (var x in parameters)
+        {
+            FastEnum.TryParse<TEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
+            r1.Should().Be(x.value);
+
+            var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
+            FastEnum.TryParse<TEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
+            r2.Should().Be(x.value);
+        }
+        FastEnum.TryParse<TEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>(" ", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("123", ignoreCase, out var r).Should().BeTrue();
+        r.Should().Be((TEnum)123);
+    }
+
+
+    [TestMethod]
+    public void TryParseIgnoreCase()
+    {
+        const bool ignoreCase = true;
+        var parameters = new[]
+        {
+            (value: TEnum.A, name: nameof(TEnum.A)),
+            (value: TEnum.A, name: nameof(TEnum.a)),
+            (value: TEnum.b, name: nameof(TEnum.b)),
+            (value: TEnum.b, name: nameof(TEnum.B)),
+            (value: TEnum.C, name: nameof(TEnum.C)),
+        };
+        foreach (var x in parameters)
+        {
+            FastEnum.TryParse<TEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
+            r1.Should().Be(x.value);
+
+            var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
+            FastEnum.TryParse<TEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
+            r2.Should().Be(x.value);
+        }
+        FastEnum.TryParse<TEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>(" ", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
+        FastEnum.TryParse<TEnum>("123", ignoreCase, out var r).Should().BeTrue();
+        r.Should().Be((TEnum)123);
+    }
+}

--- a/src/insights/FastEnum.UnitTests/Models/Boosters.cs
+++ b/src/insights/FastEnum.UnitTests/Models/Boosters.cs
@@ -65,3 +65,9 @@ public sealed partial class SameValueDiscontinuousEnumBooster
 [FastEnum<EmptyEnum>]
 public sealed partial class EmptyEnumBooster
 { }
+
+
+
+[FastEnum<CaseInsensitiveEnum>]
+public sealed partial class CaseInsensitiveEnumBooster
+{ }

--- a/src/insights/FastEnum.UnitTests/Models/Enums.cs
+++ b/src/insights/FastEnum.UnitTests/Models/Enums.cs
@@ -260,3 +260,14 @@ public enum SameValueDiscontinuousEnum : byte
 
 public enum EmptyEnum
 { }
+
+
+
+public enum CaseInsensitiveEnum : byte
+{
+    A = 1,
+    a,
+    b,
+    B,
+    C,
+}

--- a/src/libs/FastEnum.Core/Internals/EnumInfo.cs
+++ b/src/libs/FastEnum.Core/Internals/EnumInfo.cs
@@ -47,7 +47,10 @@ internal static class EnumInfo<T>
             .DistinctBy(static x => x.Value)
             .ToArray();
         s_memberByNameCaseSensitive = s_members.ToCaseSensitiveStringDictionary(static x => x.Name);
-        s_memberByNameCaseInsensitive = s_members.ToCaseInsensitiveStringDictionary(static x => x.Name);
+        s_memberByNameCaseInsensitive
+            = s_members
+            .DistinctBy(static x => x.Name, StringComparer.OrdinalIgnoreCase)
+            .ToCaseInsensitiveStringDictionary(static x => x.Name);
         s_memberByValue = s_orderedMembers.ToFastReadOnlyDictionary(static x => x.Value);
         s_minValue = s_values.DefaultIfEmpty().Min();
         s_maxValue = s_values.DefaultIfEmpty().Max();


### PR DESCRIPTION
# Summary
This PR implements safeguards to prevent exceptions during case-insensitive dictionary generation. Specifically, when an enumeration contains definitions with identical names differing only in case (e.g., `A` and `a`), the library now removes duplicates prior to dictionary generation as a preventive measure.

# Related issues
- #58 