### PR TITLE
Prefer `Unsafe.BitCast()` to `Unsafe.As()`

### DIFF
--- a/src/libs/FastEnum.Core/FastEnumExtensions.cs
+++ b/src/libs/FastEnum.Core/FastEnumExtensions.cs
@@ -65,7 +65,7 @@ public static class FastEnumExtensions
         where T : struct, Enum
     {
         ThrowHelper.ThrowIfUnderlyingTypeMismatch<T, sbyte>(nameof(value));
-        return Unsafe.As<T, sbyte>(ref value);
+        return Unsafe.BitCast<T, sbyte>(value);
     }
 
 
@@ -81,7 +81,7 @@ public static class FastEnumExtensions
         where T : struct, Enum
     {
         ThrowHelper.ThrowIfUnderlyingTypeMismatch<T, byte>(nameof(value));
-        return Unsafe.As<T, byte>(ref value);
+        return Unsafe.BitCast<T, byte>(value);
     }
 
 
@@ -97,7 +97,7 @@ public static class FastEnumExtensions
         where T : struct, Enum
     {
         ThrowHelper.ThrowIfUnderlyingTypeMismatch<T, short>(nameof(value));
-        return Unsafe.As<T, short>(ref value);
+        return Unsafe.BitCast<T, short>(value);
     }
 
 
@@ -113,7 +113,7 @@ public static class FastEnumExtensions
         where T : struct, Enum
     {
         ThrowHelper.ThrowIfUnderlyingTypeMismatch<T, ushort>(nameof(value));
-        return Unsafe.As<T, ushort>(ref value);
+        return Unsafe.BitCast<T, ushort>(value);
     }
 
 
@@ -129,7 +129,7 @@ public static class FastEnumExtensions
         where T : struct, Enum
     {
         ThrowHelper.ThrowIfUnderlyingTypeMismatch<T, int>(nameof(value));
-        return Unsafe.As<T, int>(ref value);
+        return Unsafe.BitCast<T, int>(value);
     }
 
 
@@ -145,7 +145,7 @@ public static class FastEnumExtensions
         where T : struct, Enum
     {
         ThrowHelper.ThrowIfUnderlyingTypeMismatch<T, uint>(nameof(value));
-        return Unsafe.As<T, uint>(ref value);
+        return Unsafe.BitCast<T, uint>(value);
     }
 
 
@@ -161,7 +161,7 @@ public static class FastEnumExtensions
         where T : struct, Enum
     {
         ThrowHelper.ThrowIfUnderlyingTypeMismatch<T, long>(nameof(value));
-        return Unsafe.As<T, long>(ref value);
+        return Unsafe.BitCast<T, long>(value);
     }
 
 
@@ -177,7 +177,7 @@ public static class FastEnumExtensions
         where T : struct, Enum
     {
         ThrowHelper.ThrowIfUnderlyingTypeMismatch<T, ulong>(nameof(value));
-        return Unsafe.As<T, ulong>(ref value);
+        return Unsafe.BitCast<T, ulong>(value);
     }
     #endregion
 

--- a/src/libs/FastEnum.Core/Internals/EnumInfo.cs
+++ b/src/libs/FastEnum.Core/Internals/EnumInfo.cs
@@ -75,14 +75,14 @@ internal static class EnumInfo<T>
         {
             return s_typeCode switch
             {
-                TypeCode.SByte => (ulong)Unsafe.As<T, sbyte>(ref value),
-                TypeCode.Byte => Unsafe.As<T, byte>(ref value),
-                TypeCode.Int16 => (ulong)Unsafe.As<T, short>(ref value),
-                TypeCode.UInt16 => Unsafe.As<T, ushort>(ref value),
-                TypeCode.Int32 => (ulong)Unsafe.As<T, int>(ref value),
-                TypeCode.UInt32 => Unsafe.As<T, uint>(ref value),
-                TypeCode.Int64 => (ulong)Unsafe.As<T, long>(ref value),
-                TypeCode.UInt64 => Unsafe.As<T, ulong>(ref value),
+                TypeCode.SByte => (ulong)Unsafe.BitCast<T, sbyte>(value),
+                TypeCode.Byte => Unsafe.BitCast<T, byte>(value),
+                TypeCode.Int16 => (ulong)Unsafe.BitCast<T, short>(value),
+                TypeCode.UInt16 => Unsafe.BitCast<T, ushort>(value),
+                TypeCode.Int32 => (ulong)Unsafe.BitCast<T, int>(value),
+                TypeCode.UInt32 => Unsafe.BitCast<T, uint>(value),
+                TypeCode.Int64 => (ulong)Unsafe.BitCast<T, long>(value),
+                TypeCode.UInt64 => Unsafe.BitCast<T, ulong>(value),
                 _ => throw new InvalidOperationException(),
             };
         }

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
@@ -173,7 +173,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static sbyte toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, sbyte>(ref value);
+                var x = Unsafe.BitCast<T, sbyte>(value);
                 return x;
             }
             #endregion
@@ -183,7 +183,7 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
-            ref var x = ref Unsafe.As<T, sbyte>(ref value);
+            var x = Unsafe.BitCast<T, sbyte>(value);
             return x.ToString(null, CultureInfo.InvariantCulture);
         }
 
@@ -227,7 +227,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static sbyte toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, sbyte>(ref value);
+                var x = Unsafe.BitCast<T, sbyte>(value);
                 return x;
             }
             #endregion
@@ -263,7 +263,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static byte toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, byte>(ref value);
+                var x = Unsafe.BitCast<T, byte>(value);
                 return x;
             }
             #endregion
@@ -273,7 +273,7 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
-            ref var x = ref Unsafe.As<T, byte>(ref value);
+            var x = Unsafe.BitCast<T, byte>(value);
             return x.ToString(null, CultureInfo.InvariantCulture);
         }
 
@@ -317,7 +317,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static byte toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, byte>(ref value);
+                var x = Unsafe.BitCast<T, byte>(value);
                 return x;
             }
             #endregion
@@ -353,7 +353,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static short toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, short>(ref value);
+                var x = Unsafe.BitCast<T, short>(value);
                 return x;
             }
             #endregion
@@ -363,7 +363,7 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
-            ref var x = ref Unsafe.As<T, short>(ref value);
+            var x = Unsafe.BitCast<T, short>(value);
             return x.ToString(null, CultureInfo.InvariantCulture);
         }
 
@@ -407,7 +407,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static short toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, short>(ref value);
+                var x = Unsafe.BitCast<T, short>(value);
                 return x;
             }
             #endregion
@@ -443,7 +443,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static ushort toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, ushort>(ref value);
+                var x = Unsafe.BitCast<T, ushort>(value);
                 return x;
             }
             #endregion
@@ -453,7 +453,7 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
-            ref var x = ref Unsafe.As<T, ushort>(ref value);
+            var x = Unsafe.BitCast<T, ushort>(value);
             return x.ToString(null, CultureInfo.InvariantCulture);
         }
 
@@ -497,7 +497,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static ushort toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, ushort>(ref value);
+                var x = Unsafe.BitCast<T, ushort>(value);
                 return x;
             }
             #endregion
@@ -533,7 +533,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static int toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, int>(ref value);
+                var x = Unsafe.BitCast<T, int>(value);
                 return x;
             }
             #endregion
@@ -543,7 +543,7 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
-            ref var x = ref Unsafe.As<T, int>(ref value);
+            var x = Unsafe.BitCast<T, int>(value);
             return x.ToString(null, CultureInfo.InvariantCulture);
         }
 
@@ -587,7 +587,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static int toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, int>(ref value);
+                var x = Unsafe.BitCast<T, int>(value);
                 return x;
             }
             #endregion
@@ -623,7 +623,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static uint toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, uint>(ref value);
+                var x = Unsafe.BitCast<T, uint>(value);
                 return x;
             }
             #endregion
@@ -633,7 +633,7 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
-            ref var x = ref Unsafe.As<T, uint>(ref value);
+            var x = Unsafe.BitCast<T, uint>(value);
             return x.ToString(null, CultureInfo.InvariantCulture);
         }
 
@@ -677,7 +677,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static uint toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, uint>(ref value);
+                var x = Unsafe.BitCast<T, uint>(value);
                 return x;
             }
             #endregion
@@ -713,7 +713,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static long toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, long>(ref value);
+                var x = Unsafe.BitCast<T, long>(value);
                 return x;
             }
             #endregion
@@ -723,7 +723,7 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
-            ref var x = ref Unsafe.As<T, long>(ref value);
+            var x = Unsafe.BitCast<T, long>(value);
             return x.ToString(null, CultureInfo.InvariantCulture);
         }
 
@@ -767,7 +767,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static long toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, long>(ref value);
+                var x = Unsafe.BitCast<T, long>(value);
                 return x;
             }
             #endregion
@@ -803,7 +803,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static ulong toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, ulong>(ref value);
+                var x = Unsafe.BitCast<T, ulong>(value);
                 return x;
             }
             #endregion
@@ -813,7 +813,7 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
-            ref var x = ref Unsafe.As<T, ulong>(ref value);
+            var x = Unsafe.BitCast<T, ulong>(value);
             return x.ToString(null, CultureInfo.InvariantCulture);
         }
 
@@ -857,7 +857,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static ulong toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, ulong>(ref value);
+                var x = Unsafe.BitCast<T, ulong>(value);
                 return x;
             }
             #endregion

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
@@ -139,7 +139,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static <#= x.CompatibleName #> toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, <#= x.CompatibleName #>>(ref value);
+                var x = Unsafe.BitCast<T, <#= x.CompatibleName #>>(value);
                 return x;
             }
             #endregion
@@ -149,7 +149,7 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
-            ref var x = ref Unsafe.As<T, <#= x.CompatibleName #>>(ref value);
+            var x = Unsafe.BitCast<T, <#= x.CompatibleName #>>(value);
             return x.ToString(null, CultureInfo.InvariantCulture);
         }
 
@@ -193,7 +193,7 @@ internal static class UnderlyingOperation<T>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static <#= x.CompatibleName #> toNumber(T value)
             {
-                ref var x = ref Unsafe.As<T, <#= x.CompatibleName #>>(ref value);
+                var x = Unsafe.BitCast<T, <#= x.CompatibleName #>>(value);
                 return x;
             }
             #endregion


### PR DESCRIPTION
# Summary
Compared to `Unsafe.As()`, `Unsafe.BitCast()` provides a safer type conversion that is more amenable to JIT optimization. Therefore, we will make adjustments to utilize `Unsafe.BitCast()` wherever possible.


# Reference
- https://blog.neno.dev/entry/2025/01/07/182438