### PR TITLE
Optimize ThrowIfUnderlyingTypeMismatch

### DIFF
--- a/src/libs/FastEnum.Core/Internals/ThrowHelper.cs
+++ b/src/libs/FastEnum.Core/Internals/ThrowHelper.cs
@@ -12,11 +12,14 @@ internal static class ThrowHelper
         where TEnum : struct, Enum
         where TUnderlying : INumberBase<TUnderlying>
     {
-        if (FastEnum.GetUnderlyingType<TEnum>() == typeof(TUnderlying))
+        if (Enum.GetUnderlyingType(typeof(TEnum)) == typeof(TUnderlying))
             return;
-
-        const string message = $"The underlying type of the enum and the value must be the same type.";
-        throw new ArgumentException(message, paramName);
+        ThrowArgumentException(paramName);
+        static void ThrowArgumentException(string? paramName)
+        {
+            const string message = $"The underlying type of the enum and the value must be the same type.";
+            throw new ArgumentException(message, paramName);
+        }
     }
 
 


### PR DESCRIPTION
```cs
FastEnum.GetUnderlyingType<TEnum>() == typeof(TUnderlying)
```
First of all, this part is not optimized by JIT.
`throw` also prevents inline conversion.

The following code can be confirmed to disappear completely with JIT.
```cs
using System;
using System.Numerics;
using System.Runtime.CompilerServices;


int a = ToInt32(TestEnum.A);

[MethodImpl(MethodImplOptions.AggressiveInlining)]
static int ToInt32<T>(T value)
    where T : struct, Enum
{
    ThrowIfUnderlyingTypeMismatch<T, int>(nameof(value));
    return Unsafe.As<T, int>(ref value);
}

static void ThrowIfUnderlyingTypeMismatch<TEnum, TUnderlying>(string? paramName)
    where TEnum : struct, Enum
    where TUnderlying : INumberBase<TUnderlying>
{
     if (Enum.GetUnderlyingType(typeof(TEnum)) == typeof(TUnderlying))
        return;
    ThrowArgumentException(paramName);
    static void ThrowArgumentException(string? paramName)
    {
        const string message = $"The underlying type of the enum and the value must be the same type.";
        throw new ArgumentException(message, paramName);
    }
}
enum TestEnum{
    A,
    B
}
```
[Sharplab](https://sharplab.io/#v2:EYLgtghglgdgNAFxBAzmAPgAQEwAYCwAUDgIxGa4AEmJAdAHICuYApgE5QDGKA3OVTVoAlRjARRWtAMIB7MAAcoAG3YBldgDcuLXkT2FYCShEoBeSgBUZASTEBmbAAoLOhAFEYzWgEEAlH0IiAG0AWRYEAAsZABNrBSVHMMiYuPklAHl5cRkYFB8Ac3y2HRQoDRZbJVhYfN8AXXISADZKQ0sbe2wAHgsAPmdKDQglRhZfIkpJygB3CPYWS0oQShQENkZOBDhKD2YiAG8JqYsIthlp6wAzAFUYaPYlAE8ai0f5FhCoNAgETgie7aGfowCCsGSXRxDEZjfxHSaYADslFuKAglxYPhQANaYn6xUug2Go1hhAAvvoaC1MAAWSync5XW73NhPF5vD5fSC/f4WXZgbYWJkPZ4wfL9Gi4AD8lHkEDYoPooLGcJmc2Klj5SxWaw2Wx2njAKtm80sQpZIvyWusTDAwHYACFUCwembWaLegcVa0CY4+bQAOLhV0W17vRwIdng5x83y+MzmCPvKOCu7Cmqxr1TREBKZ0s7TbxsfLMFhiNwAD04LCyUByjll8rAitYJNzlOotJO+cLxdYZcr1eyMEcEulDYVSvGhFzh2nuamnByq2oJCorBQqPyC3MABIAEQnBaiZluy2JhbgyiRBal5jGO5XuaE6GUMCMZd2x8LVGsK/s2h7jm86TJE+aUDALDTJQPYlv2VY1nW66biw2zjk2k5AZM5JkkQt5gJYrh8rOubeHAKr2kQpJAA)