### PR TITLE
Improve the initial performance of `.GetUnderlyingType<T>()` method

### DIFF
--- a/src/libs/FastEnum.Core/FastEnum.cs
+++ b/src/libs/FastEnum.Core/FastEnum.cs
@@ -22,7 +22,7 @@ public static partial class FastEnum
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Type GetUnderlyingType<T>()
         where T : struct, Enum
-        => EnumInfo<T>.s_underlyingType;
+        => Enum.GetUnderlyingType(typeof(T));
     #endregion
 
 

--- a/src/libs/FastEnum.Core/Internals/EnumInfo.cs
+++ b/src/libs/FastEnum.Core/Internals/EnumInfo.cs
@@ -15,7 +15,6 @@ internal static class EnumInfo<T>
 {
     #region Fields
     public static readonly Type s_type;
-    public static readonly Type s_underlyingType;
     public static readonly TypeCode s_typeCode;
     public static readonly string[] s_names;
     public static readonly T[] s_values;
@@ -36,7 +35,6 @@ internal static class EnumInfo<T>
     static EnumInfo()
     {
         s_type = typeof(T);
-        s_underlyingType = Enum.GetUnderlyingType(s_type);
         s_typeCode = Type.GetTypeCode(s_type);
         s_names = Enum.GetNames(s_type);
         s_values = (T[])Enum.GetValues(s_type);


### PR DESCRIPTION
# Summary
Improve performance by avoiding the initialization of `EnumInfo<T>`.

# Hint
- #66