### PR TITLE
goto Shouldly;

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Enums.NET" Version="5.0.0" />
     <PackageVersion Include="FluentAssertions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-    <PackageVersion Include="MSTest" Version="3.7.0" />
+    <PackageVersion Include="MSTest" Version="3.8.0" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta11" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
   </ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,6 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Enums.NET" Version="5.0.0" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageVersion Include="MSTest" Version="3.8.0" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta11" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,5 +9,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageVersion Include="MSTest" Version="3.7.0" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta11" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/insights/FastEnum.UnitTests/Cases/Generators/BasicTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Generators/BasicTests.cs
@@ -8,8 +8,8 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Generators;
 
@@ -26,16 +26,16 @@ public sealed class BasicSByteTests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName<SByteEnum, SByteEnumBooster>(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const SByteEnum undefined = (SByteEnum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName<SByteEnum, SByteEnumBooster>(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -44,17 +44,17 @@ public sealed class BasicSByteTests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(SByteEnum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(SByteEnum.Zero).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(SByteEnum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>((SByteEnum)123).Should().BeFalse();
+        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(SByteEnum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(SByteEnum.Zero).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(SByteEnum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>((SByteEnum)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(nameof(SByteEnum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(nameof(SByteEnum.Zero)).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(nameof(SByteEnum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>("123").Should().BeFalse();
-        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(nameof(SByteEnum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(nameof(SByteEnum.Zero)).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>(nameof(SByteEnum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>("123").ShouldBeFalse();
+        FastEnum.IsDefined<SByteEnum, SByteEnumBooster>("minvalue").ShouldBeFalse();
     }
 
 
@@ -71,18 +71,18 @@ public sealed class BasicSByteTests
         foreach (var x in parameters)
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SByteEnum, SByteEnumBooster>("123", ignoreCase).Should().Be((SByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<SByteEnum, SByteEnumBooster>("123", ignoreCase).ShouldBe((SByteEnum)123);
     }
 
 
@@ -99,18 +99,18 @@ public sealed class BasicSByteTests
         foreach (var x in parameters)
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum, SByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum, SByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SByteEnum, SByteEnumBooster>("123", ignoreCase).Should().Be((SByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum, SByteEnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<SByteEnum, SByteEnumBooster>("123", ignoreCase).ShouldBe((SByteEnum)123);
     }
 
 
@@ -128,27 +128,27 @@ public sealed class BasicSByteTests
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SByteEnum, SByteEnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum, SByteEnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SByteEnum)123);
+        FastEnum.TryParse<SByteEnum, SByteEnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum, SByteEnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SByteEnum)123);
     }
 
 
@@ -166,30 +166,30 @@ public sealed class BasicSByteTests
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum, SByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SByteEnum, SByteEnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum, SByteEnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SByteEnum)123);
+        FastEnum.TryParse<SByteEnum, SByteEnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum, SByteEnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum, SByteEnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SByteEnum)123);
     }
 
 
@@ -202,7 +202,7 @@ public sealed class BasicSByteTests
         {
             var expect = x.ToString();
             var actual = FastEnum.ToString<SByteEnum, SByteEnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -220,16 +220,16 @@ public sealed class BasicByteTests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName<ByteEnum, ByteEnumBooster>(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const ByteEnum undefined = (ByteEnum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName<ByteEnum, ByteEnumBooster>(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -238,15 +238,15 @@ public sealed class BasicByteTests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>(ByteEnum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>(ByteEnum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>((ByteEnum)123).Should().BeFalse();
+        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>(ByteEnum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>(ByteEnum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>((ByteEnum)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>(nameof(ByteEnum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>(nameof(ByteEnum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>("123").Should().BeFalse();
-        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>(nameof(ByteEnum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>(nameof(ByteEnum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>("123").ShouldBeFalse();
+        FastEnum.IsDefined<ByteEnum, ByteEnumBooster>("minvalue").ShouldBeFalse();
     }
 
 
@@ -262,18 +262,18 @@ public sealed class BasicByteTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ByteEnum, ByteEnumBooster>("123", ignoreCase).Should().Be((ByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<ByteEnum, ByteEnumBooster>("123", ignoreCase).ShouldBe((ByteEnum)123);
     }
 
 
@@ -289,18 +289,18 @@ public sealed class BasicByteTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum, ByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum, ByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ByteEnum, ByteEnumBooster>("123", ignoreCase).Should().Be((ByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum, ByteEnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<ByteEnum, ByteEnumBooster>("123", ignoreCase).ShouldBe((ByteEnum)123);
     }
 
 
@@ -317,27 +317,27 @@ public sealed class BasicByteTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ByteEnum, ByteEnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum, ByteEnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ByteEnum)123);
+        FastEnum.TryParse<ByteEnum, ByteEnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum, ByteEnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ByteEnum)123);
     }
 
 
@@ -354,30 +354,30 @@ public sealed class BasicByteTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum, ByteEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ByteEnum, ByteEnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum, ByteEnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ByteEnum)123);
+        FastEnum.TryParse<ByteEnum, ByteEnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum, ByteEnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum, ByteEnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ByteEnum)123);
     }
 
 
@@ -390,7 +390,7 @@ public sealed class BasicByteTests
         {
             var expect = x.ToString();
             var actual = FastEnum.ToString<ByteEnum, ByteEnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -408,16 +408,16 @@ public sealed class BasicInt16Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName<Int16Enum, Int16EnumBooster>(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const Int16Enum undefined = (Int16Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName<Int16Enum, Int16EnumBooster>(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -426,17 +426,17 @@ public sealed class BasicInt16Tests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(Int16Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(Int16Enum.Zero).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(Int16Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>((Int16Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(Int16Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(Int16Enum.Zero).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(Int16Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>((Int16Enum)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(nameof(Int16Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(nameof(Int16Enum.Zero)).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(nameof(Int16Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>("123").Should().BeFalse();
-        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(nameof(Int16Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(nameof(Int16Enum.Zero)).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>(nameof(Int16Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>("123").ShouldBeFalse();
+        FastEnum.IsDefined<Int16Enum, Int16EnumBooster>("minvalue").ShouldBeFalse();
     }
 
 
@@ -453,18 +453,18 @@ public sealed class BasicInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int16Enum, Int16EnumBooster>("123", ignoreCase).Should().Be((Int16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int16Enum, Int16EnumBooster>("123", ignoreCase).ShouldBe((Int16Enum)123);
     }
 
 
@@ -481,18 +481,18 @@ public sealed class BasicInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum, Int16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum, Int16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int16Enum, Int16EnumBooster>("123", ignoreCase).Should().Be((Int16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum, Int16EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int16Enum, Int16EnumBooster>("123", ignoreCase).ShouldBe((Int16Enum)123);
     }
 
 
@@ -510,27 +510,27 @@ public sealed class BasicInt16Tests
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int16Enum, Int16EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum, Int16EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int16Enum)123);
+        FastEnum.TryParse<Int16Enum, Int16EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum, Int16EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int16Enum)123);
     }
 
 
@@ -548,30 +548,30 @@ public sealed class BasicInt16Tests
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum, Int16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int16Enum, Int16EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum, Int16EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int16Enum)123);
+        FastEnum.TryParse<Int16Enum, Int16EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum, Int16EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum, Int16EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int16Enum)123);
     }
 
 
@@ -584,7 +584,7 @@ public sealed class BasicInt16Tests
         {
             var expect = x.ToString();
             var actual = FastEnum.ToString<Int16Enum, Int16EnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -602,16 +602,16 @@ public sealed class BasicUInt16Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName<UInt16Enum, UInt16EnumBooster>(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const UInt16Enum undefined = (UInt16Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName<UInt16Enum, UInt16EnumBooster>(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -620,15 +620,15 @@ public sealed class BasicUInt16Tests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>(UInt16Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>(UInt16Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>((UInt16Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>(UInt16Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>(UInt16Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>((UInt16Enum)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>(nameof(UInt16Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>(nameof(UInt16Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>("123").Should().BeFalse();
-        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>(nameof(UInt16Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>(nameof(UInt16Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>("123").ShouldBeFalse();
+        FastEnum.IsDefined<UInt16Enum, UInt16EnumBooster>("minvalue").ShouldBeFalse();
     }
 
 
@@ -644,18 +644,18 @@ public sealed class BasicUInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("123", ignoreCase).Should().Be((UInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("123", ignoreCase).ShouldBe((UInt16Enum)123);
     }
 
 
@@ -671,18 +671,18 @@ public sealed class BasicUInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("123", ignoreCase).Should().Be((UInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt16Enum, UInt16EnumBooster>("123", ignoreCase).ShouldBe((UInt16Enum)123);
     }
 
 
@@ -699,27 +699,27 @@ public sealed class BasicUInt16Tests
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt16Enum)123);
+        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt16Enum)123);
     }
 
 
@@ -736,30 +736,30 @@ public sealed class BasicUInt16Tests
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt16Enum)123);
+        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum, UInt16EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt16Enum)123);
     }
 
 
@@ -772,7 +772,7 @@ public sealed class BasicUInt16Tests
         {
             var expect = x.ToString();
             var actual = FastEnum.ToString<UInt16Enum, UInt16EnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -790,16 +790,16 @@ public sealed class BasicInt32Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName<Int32Enum, Int32EnumBooster>(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const Int32Enum undefined = (Int32Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName<Int32Enum, Int32EnumBooster>(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -808,17 +808,17 @@ public sealed class BasicInt32Tests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(Int32Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(Int32Enum.Zero).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(Int32Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>((Int32Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(Int32Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(Int32Enum.Zero).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(Int32Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>((Int32Enum)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(nameof(Int32Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(nameof(Int32Enum.Zero)).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(nameof(Int32Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>("123").Should().BeFalse();
-        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(nameof(Int32Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(nameof(Int32Enum.Zero)).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>(nameof(Int32Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>("123").ShouldBeFalse();
+        FastEnum.IsDefined<Int32Enum, Int32EnumBooster>("minvalue").ShouldBeFalse();
     }
 
 
@@ -835,18 +835,18 @@ public sealed class BasicInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int32Enum, Int32EnumBooster>("123", ignoreCase).Should().Be((Int32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int32Enum, Int32EnumBooster>("123", ignoreCase).ShouldBe((Int32Enum)123);
     }
 
 
@@ -863,18 +863,18 @@ public sealed class BasicInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum, Int32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum, Int32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int32Enum, Int32EnumBooster>("123", ignoreCase).Should().Be((Int32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum, Int32EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int32Enum, Int32EnumBooster>("123", ignoreCase).ShouldBe((Int32Enum)123);
     }
 
 
@@ -892,27 +892,27 @@ public sealed class BasicInt32Tests
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int32Enum, Int32EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum, Int32EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int32Enum)123);
+        FastEnum.TryParse<Int32Enum, Int32EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum, Int32EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int32Enum)123);
     }
 
 
@@ -930,30 +930,30 @@ public sealed class BasicInt32Tests
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum, Int32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int32Enum, Int32EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum, Int32EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int32Enum)123);
+        FastEnum.TryParse<Int32Enum, Int32EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum, Int32EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum, Int32EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int32Enum)123);
     }
 
 
@@ -966,7 +966,7 @@ public sealed class BasicInt32Tests
         {
             var expect = x.ToString();
             var actual = FastEnum.ToString<Int32Enum, Int32EnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -984,16 +984,16 @@ public sealed class BasicUInt32Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName<UInt32Enum, UInt32EnumBooster>(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const UInt32Enum undefined = (UInt32Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName<UInt32Enum, UInt32EnumBooster>(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1002,15 +1002,15 @@ public sealed class BasicUInt32Tests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>(UInt32Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>(UInt32Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>((UInt32Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>(UInt32Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>(UInt32Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>((UInt32Enum)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>(nameof(UInt32Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>(nameof(UInt32Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>("123").Should().BeFalse();
-        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>(nameof(UInt32Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>(nameof(UInt32Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>("123").ShouldBeFalse();
+        FastEnum.IsDefined<UInt32Enum, UInt32EnumBooster>("minvalue").ShouldBeFalse();
     }
 
 
@@ -1026,18 +1026,18 @@ public sealed class BasicUInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("123", ignoreCase).Should().Be((UInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("123", ignoreCase).ShouldBe((UInt32Enum)123);
     }
 
 
@@ -1053,18 +1053,18 @@ public sealed class BasicUInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("123", ignoreCase).Should().Be((UInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt32Enum, UInt32EnumBooster>("123", ignoreCase).ShouldBe((UInt32Enum)123);
     }
 
 
@@ -1081,27 +1081,27 @@ public sealed class BasicUInt32Tests
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt32Enum)123);
+        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt32Enum)123);
     }
 
 
@@ -1118,30 +1118,30 @@ public sealed class BasicUInt32Tests
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt32Enum)123);
+        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum, UInt32EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt32Enum)123);
     }
 
 
@@ -1154,7 +1154,7 @@ public sealed class BasicUInt32Tests
         {
             var expect = x.ToString();
             var actual = FastEnum.ToString<UInt32Enum, UInt32EnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1172,16 +1172,16 @@ public sealed class BasicInt64Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName<Int64Enum, Int64EnumBooster>(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const Int64Enum undefined = (Int64Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName<Int64Enum, Int64EnumBooster>(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1190,17 +1190,17 @@ public sealed class BasicInt64Tests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(Int64Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(Int64Enum.Zero).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(Int64Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>((Int64Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(Int64Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(Int64Enum.Zero).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(Int64Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>((Int64Enum)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(nameof(Int64Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(nameof(Int64Enum.Zero)).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(nameof(Int64Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>("123").Should().BeFalse();
-        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(nameof(Int64Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(nameof(Int64Enum.Zero)).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>(nameof(Int64Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>("123").ShouldBeFalse();
+        FastEnum.IsDefined<Int64Enum, Int64EnumBooster>("minvalue").ShouldBeFalse();
     }
 
 
@@ -1217,18 +1217,18 @@ public sealed class BasicInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int64Enum, Int64EnumBooster>("123", ignoreCase).Should().Be((Int64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int64Enum, Int64EnumBooster>("123", ignoreCase).ShouldBe((Int64Enum)123);
     }
 
 
@@ -1245,18 +1245,18 @@ public sealed class BasicInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum, Int64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum, Int64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int64Enum, Int64EnumBooster>("123", ignoreCase).Should().Be((Int64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum, Int64EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int64Enum, Int64EnumBooster>("123", ignoreCase).ShouldBe((Int64Enum)123);
     }
 
 
@@ -1274,27 +1274,27 @@ public sealed class BasicInt64Tests
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int64Enum, Int64EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum, Int64EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int64Enum)123);
+        FastEnum.TryParse<Int64Enum, Int64EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum, Int64EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int64Enum)123);
     }
 
 
@@ -1312,30 +1312,30 @@ public sealed class BasicInt64Tests
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum, Int64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int64Enum, Int64EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum, Int64EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int64Enum)123);
+        FastEnum.TryParse<Int64Enum, Int64EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum, Int64EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum, Int64EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int64Enum)123);
     }
 
 
@@ -1348,7 +1348,7 @@ public sealed class BasicInt64Tests
         {
             var expect = x.ToString();
             var actual = FastEnum.ToString<Int64Enum, Int64EnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1366,16 +1366,16 @@ public sealed class BasicUInt64Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName<UInt64Enum, UInt64EnumBooster>(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const UInt64Enum undefined = (UInt64Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName<UInt64Enum, UInt64EnumBooster>(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1384,15 +1384,15 @@ public sealed class BasicUInt64Tests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>(UInt64Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>(UInt64Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>((UInt64Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>(UInt64Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>(UInt64Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>((UInt64Enum)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>(nameof(UInt64Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>(nameof(UInt64Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>("123").Should().BeFalse();
-        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>(nameof(UInt64Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>(nameof(UInt64Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>("123").ShouldBeFalse();
+        FastEnum.IsDefined<UInt64Enum, UInt64EnumBooster>("minvalue").ShouldBeFalse();
     }
 
 
@@ -1408,18 +1408,18 @@ public sealed class BasicUInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("123", ignoreCase).Should().Be((UInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("123", ignoreCase).ShouldBe((UInt64Enum)123);
     }
 
 
@@ -1435,18 +1435,18 @@ public sealed class BasicUInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("123", ignoreCase).Should().Be((UInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt64Enum, UInt64EnumBooster>("123", ignoreCase).ShouldBe((UInt64Enum)123);
     }
 
 
@@ -1463,27 +1463,27 @@ public sealed class BasicUInt64Tests
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt64Enum)123);
+        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt64Enum)123);
     }
 
 
@@ -1500,30 +1500,30 @@ public sealed class BasicUInt64Tests
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt64Enum)123);
+        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum, UInt64EnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt64Enum)123);
     }
 
 
@@ -1536,7 +1536,7 @@ public sealed class BasicUInt64Tests
         {
             var expect = x.ToString();
             var actual = FastEnum.ToString<UInt64Enum, UInt64EnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Generators/BasicTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/Generators/BasicTests.tt
@@ -26,8 +26,8 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Generators;
 
@@ -45,16 +45,16 @@ public sealed class Basic<#= x.AliasType #>Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName<<#= x.EnumType #>, <#= x.BoosterType #>>(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const <#= x.EnumType #> undefined = (<#= x.EnumType #>)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName<<#= x.EnumType #>, <#= x.BoosterType #>>(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -63,21 +63,21 @@ public sealed class Basic<#= x.AliasType #>Tests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.MinValue).Should().BeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.MinValue).ShouldBeTrue();
 <# if (x.IsSignedType) { #>
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.Zero).Should().BeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.Zero).ShouldBeTrue();
 <# } #>
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>((<#= x.EnumType #>)123).Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>((<#= x.EnumType #>)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.MinValue)).Should().BeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.MinValue)).ShouldBeTrue();
 <# if (x.IsSignedType) { #>
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.Zero)).Should().BeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.Zero)).ShouldBeTrue();
 <# } #>
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>("123").Should().BeFalse();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>("123").ShouldBeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>("minvalue").ShouldBeFalse();
     }
 
 
@@ -96,18 +96,18 @@ public sealed class Basic<#= x.AliasType #>Tests
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -126,18 +126,18 @@ public sealed class Basic<#= x.AliasType #>Tests
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -157,27 +157,27 @@ public sealed class Basic<#= x.AliasType #>Tests
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -197,30 +197,30 @@ public sealed class Basic<#= x.AliasType #>Tests
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -233,7 +233,7 @@ public sealed class Basic<#= x.AliasType #>Tests
         {
             var expect = x.ToString();
             var actual = FastEnum.ToString<<#= x.EnumType #>, <#= x.BoosterType #>>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Generators/CaseInsensitiveTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Generators/CaseInsensitiveTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 using TBooster = FastEnumUtility.UnitTests.Models.CaseInsensitiveEnumBooster;
 using TEnum = FastEnumUtility.UnitTests.Models.CaseInsensitiveEnum;
 
@@ -27,14 +27,14 @@ public class CaseInsensitiveTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<TEnum, TBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<TEnum, TBooster>(valueString, ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<TEnum, TBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<TEnum, TBooster>(valueString, ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<TEnum, TBooster>("123", ignoreCase).Should().Be((TEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<TEnum, TBooster>("123", ignoreCase).ShouldBe((TEnum)123);
     }
 
 
@@ -53,14 +53,14 @@ public class CaseInsensitiveTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<TEnum, TBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<TEnum, TBooster>(valueString, ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<TEnum, TBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<TEnum, TBooster>(valueString, ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<TEnum, TBooster>("123", ignoreCase).Should().Be((TEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<TEnum, TBooster>("123", ignoreCase).ShouldBe((TEnum)123);
     }
 
 
@@ -78,19 +78,19 @@ public class CaseInsensitiveTests
         };
         foreach (var x in parameters)
         {
-            FastEnum.TryParse<TEnum, TBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<TEnum, TBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.TryParse<TEnum, TBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<TEnum, TBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
         }
-        FastEnum.TryParse<TEnum, TBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((TEnum)123);
+        FastEnum.TryParse<TEnum, TBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((TEnum)123);
     }
 
 
@@ -108,18 +108,18 @@ public class CaseInsensitiveTests
         };
         foreach (var x in parameters)
         {
-            FastEnum.TryParse<TEnum, TBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<TEnum, TBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.TryParse<TEnum, TBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<TEnum, TBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
         }
-        FastEnum.TryParse<TEnum, TBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((TEnum)123);
+        FastEnum.TryParse<TEnum, TBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((TEnum)123);
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Generators/EmptyTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Generators/EmptyTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 using TBooster = FastEnumUtility.UnitTests.Models.EmptyEnumBooster;
 using TEnum = FastEnumUtility.UnitTests.Models.EmptyEnum;
 
@@ -13,14 +13,14 @@ public class EmptyTests
 {
     [TestMethod]
     public void GetName()
-        => FastEnum.GetName<TEnum, TBooster>(default).Should().BeNull();
+        => FastEnum.GetName<TEnum, TBooster>(default).ShouldBeNull();
 
 
     [TestMethod]
     public void IsDefined()
     {
-        FastEnum.IsDefined<TEnum, TBooster>((TEnum)123).Should().BeFalse();
-        FastEnum.IsDefined<TEnum, TBooster>("123").Should().BeFalse();
+        FastEnum.IsDefined<TEnum, TBooster>((TEnum)123).ShouldBeFalse();
+        FastEnum.IsDefined<TEnum, TBooster>("123").ShouldBeFalse();
     }
 
 
@@ -28,11 +28,11 @@ public class EmptyTests
     public void Parse()
     {
         const bool ignoreCase = false;
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<TEnum, TBooster>("123", ignoreCase).Should().Be((TEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<TEnum, TBooster>("123", ignoreCase).ShouldBe((TEnum)123);
     }
 
 
@@ -40,11 +40,11 @@ public class EmptyTests
     public void ParseIgnoreCase()
     {
         const bool ignoreCase = true;
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum, TBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<TEnum, TBooster>("123", ignoreCase).Should().Be((TEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum, TBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<TEnum, TBooster>("123", ignoreCase).ShouldBe((TEnum)123);
     }
 
 
@@ -52,12 +52,12 @@ public class EmptyTests
     public void TryParse()
     {
         const bool ignoreCase = false;
-        FastEnum.TryParse<TEnum, TBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((TEnum)123);
+        FastEnum.TryParse<TEnum, TBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((TEnum)123);
     }
 
 
@@ -65,12 +65,12 @@ public class EmptyTests
     public void TryParseIgnoreCase()
     {
         const bool ignoreCase = true;
-        FastEnum.TryParse<TEnum, TBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum, TBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((TEnum)123);
+        FastEnum.TryParse<TEnum, TBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum, TBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((TEnum)123);
     }
 
 
@@ -80,6 +80,6 @@ public class EmptyTests
         const TEnum undefined = (TEnum)123;
         var expect = undefined.ToString();
         var actual = FastEnum.ToString<TEnum, TBooster>(undefined);
-        actual.Should().Be(expect);
+        actual.ShouldBe(expect);
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Generators/SameValueTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Generators/SameValueTests.cs
@@ -6,8 +6,8 @@
 using System;
 using System.Globalization;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Generators;
 
@@ -23,7 +23,7 @@ public sealed class SameValueContinuousTests
         {
             var expect = Enum.GetName(x);
             var actual = FastEnum.GetName<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 
@@ -32,19 +32,19 @@ public sealed class SameValueContinuousTests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(SameValueContinuousEnum.A).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(SameValueContinuousEnum.B).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(SameValueContinuousEnum.C).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(SameValueContinuousEnum.D).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>((SameValueContinuousEnum)123).Should().BeFalse();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(SameValueContinuousEnum.A).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(SameValueContinuousEnum.B).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(SameValueContinuousEnum.C).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(SameValueContinuousEnum.D).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>((SameValueContinuousEnum)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(nameof(SameValueContinuousEnum.A)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(nameof(SameValueContinuousEnum.B)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(nameof(SameValueContinuousEnum.C)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(nameof(SameValueContinuousEnum.D)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>("123").Should().BeFalse();
-        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>("value").Should().BeFalse();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(nameof(SameValueContinuousEnum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(nameof(SameValueContinuousEnum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(nameof(SameValueContinuousEnum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>(nameof(SameValueContinuousEnum.D)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>("123").ShouldBeFalse();
+        FastEnum.IsDefined<SameValueContinuousEnum, SameValueContinuousEnumBooster>("value").ShouldBeFalse();
     }
 
 
@@ -62,18 +62,18 @@ public sealed class SameValueContinuousTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("123", ignoreCase).Should().Be((SameValueContinuousEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("123", ignoreCase).ShouldBe((SameValueContinuousEnum)123);
     }
 
 
@@ -91,18 +91,18 @@ public sealed class SameValueContinuousTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("123", ignoreCase).Should().Be((SameValueContinuousEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("123", ignoreCase).ShouldBe((SameValueContinuousEnum)123);
     }
 
 
@@ -121,27 +121,27 @@ public sealed class SameValueContinuousTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SameValueContinuousEnum)123);
+        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SameValueContinuousEnum)123);
     }
 
 
@@ -160,30 +160,30 @@ public sealed class SameValueContinuousTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SameValueContinuousEnum)123);
+        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum, SameValueContinuousEnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SameValueContinuousEnum)123);
     }
 
 
@@ -195,7 +195,7 @@ public sealed class SameValueContinuousTests
         {
             var expect = Enum.GetName(x);
             var actual = FastEnum.ToString<SameValueContinuousEnum, SameValueContinuousEnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -212,7 +212,7 @@ public sealed class SameValueDiscontinuousTests
         {
             var expect = Enum.GetName(x);
             var actual = FastEnum.GetName<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 
@@ -221,19 +221,19 @@ public sealed class SameValueDiscontinuousTests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(SameValueDiscontinuousEnum.A).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(SameValueDiscontinuousEnum.B).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(SameValueDiscontinuousEnum.C).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(SameValueDiscontinuousEnum.D).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>((SameValueDiscontinuousEnum)123).Should().BeFalse();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(SameValueDiscontinuousEnum.A).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(SameValueDiscontinuousEnum.B).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(SameValueDiscontinuousEnum.C).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(SameValueDiscontinuousEnum.D).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>((SameValueDiscontinuousEnum)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(nameof(SameValueDiscontinuousEnum.A)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(nameof(SameValueDiscontinuousEnum.B)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(nameof(SameValueDiscontinuousEnum.C)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(nameof(SameValueDiscontinuousEnum.D)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("123").Should().BeFalse();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("value").Should().BeFalse();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(nameof(SameValueDiscontinuousEnum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(nameof(SameValueDiscontinuousEnum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(nameof(SameValueDiscontinuousEnum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(nameof(SameValueDiscontinuousEnum.D)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("123").ShouldBeFalse();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("value").ShouldBeFalse();
     }
 
 
@@ -251,18 +251,18 @@ public sealed class SameValueDiscontinuousTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("123", ignoreCase).Should().Be((SameValueDiscontinuousEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("123", ignoreCase).ShouldBe((SameValueDiscontinuousEnum)123);
     }
 
 
@@ -280,18 +280,18 @@ public sealed class SameValueDiscontinuousTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("123", ignoreCase).Should().Be((SameValueDiscontinuousEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("ABCDE", ignoreCase));
+        FastEnum.Parse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("123", ignoreCase).ShouldBe((SameValueDiscontinuousEnum)123);
     }
 
 
@@ -310,27 +310,27 @@ public sealed class SameValueDiscontinuousTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SameValueDiscontinuousEnum)123);
+        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SameValueDiscontinuousEnum)123);
     }
 
 
@@ -349,30 +349,30 @@ public sealed class SameValueDiscontinuousTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SameValueDiscontinuousEnum)123);
+        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SameValueDiscontinuousEnum)123);
     }
 
 
@@ -384,7 +384,7 @@ public sealed class SameValueDiscontinuousTests
         {
             var expect = Enum.GetName(x);
             var actual = FastEnum.ToString<SameValueDiscontinuousEnum, SameValueDiscontinuousEnumBooster>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Generators/SameValueTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/Generators/SameValueTests.tt
@@ -18,8 +18,8 @@
 using System;
 using System.Globalization;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Generators;
 
@@ -36,7 +36,7 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         {
             var expect = Enum.GetName(x);
             var actual = FastEnum.GetName<<#= x.EnumType #>, <#= x.BoosterType #>>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 
@@ -45,19 +45,19 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.A).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.B).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.C).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.D).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>((<#= x.EnumType #>)123).Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.A).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.B).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.C).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(<#= x.EnumType #>.D).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>((<#= x.EnumType #>)123).ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.A)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.B)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.C)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.D)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>("123").Should().BeFalse();
-        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>("value").Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.A)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.B)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.C)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>(nameof(<#= x.EnumType #>.D)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>("123").ShouldBeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>, <#= x.BoosterType #>>("value").ShouldBeFalse();
     }
 
 
@@ -75,18 +75,18 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -104,18 +104,18 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -134,27 +134,27 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -173,30 +173,30 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>, <#= x.BoosterType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -208,7 +208,7 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         {
             var expect = Enum.GetName(x);
             var actual = FastEnum.ToString<<#= x.EnumType #>, <#= x.BoosterType #>>(x);
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/AnnotationTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/AnnotationTests.cs
@@ -1,5 +1,5 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 using TEnum = FastEnumUtility.UnitTests.Models.AnnotationEnum;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
@@ -11,7 +11,7 @@ public class AnnotationTests
 {
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<TEnum>().Should().Be(true);
+        => FastEnum.IsFlags<TEnum>().ShouldBe(true);
 
 
     [TestMethod]
@@ -20,21 +20,21 @@ public class AnnotationTests
         {
             var member = TEnum.Zero.ToMember()!;
             var attr = member.EnumMemberAttribute!;
-            attr.Should().NotBeNull();
-            attr.IsValueSetExplicitly.Should().BeTrue();
-            attr.Value.Should().Be("_zero_");
+            attr.ShouldNotBeNull();
+            attr.IsValueSetExplicitly.ShouldBeTrue();
+            attr.Value.ShouldBe("_zero_");
         }
         {
             var member = TEnum.One.ToMember()!;
             var attr = member.EnumMemberAttribute!;
-            attr.Should().NotBeNull();
-            attr.IsValueSetExplicitly.Should().BeFalse();
-            attr.Value.Should().BeNull();
+            attr.ShouldNotBeNull();
+            attr.IsValueSetExplicitly.ShouldBeFalse();
+            attr.Value.ShouldBeNull();
         }
         {
             var member = TEnum.Two.ToMember()!;
             var attr = member.EnumMemberAttribute!;
-            attr.Should().BeNull();
+            attr.ShouldBeNull();
         }
     }
 
@@ -42,54 +42,42 @@ public class AnnotationTests
     [TestMethod]
     public void GetEnumMemberValue()
     {
-        TEnum.Zero.GetEnumMemberValue(throwIfNotFound: false).Should().Be("_zero_");
-        TEnum.Zero.GetEnumMemberValue(throwIfNotFound: true).Should().Be("_zero_");
+        TEnum.Zero.GetEnumMemberValue(throwIfNotFound: false).ShouldBe("_zero_");
+        TEnum.Zero.GetEnumMemberValue(throwIfNotFound: true).ShouldBe("_zero_");
 
-        TEnum.One.GetEnumMemberValue(throwIfNotFound: false).Should().BeNull();
-        TEnum.One.GetEnumMemberValue(throwIfNotFound: true).Should().BeNull();
+        TEnum.One.GetEnumMemberValue(throwIfNotFound: false).ShouldBeNull();
+        TEnum.One.GetEnumMemberValue(throwIfNotFound: true).ShouldBeNull();
 
-        TEnum.Two.GetEnumMemberValue(throwIfNotFound: false).Should().BeNull();
-        FluentActions
-            .Invoking(static () => TEnum.Two.GetEnumMemberValue(throwIfNotFound: true))
-            .Should()
-            .Throw<NotFoundException>();
+        TEnum.Two.GetEnumMemberValue(throwIfNotFound: false).ShouldBeNull();
+        Should.Throw<NotFoundException>(static () => TEnum.Two.GetEnumMemberValue(throwIfNotFound: true));
 
         const TEnum undefined = (TEnum)123;
-        undefined.GetEnumMemberValue(throwIfNotFound: false).Should().BeNull();
-        FluentActions
-            .Invoking(static () => undefined.GetEnumMemberValue(throwIfNotFound: true))
-            .Should()
-            .Throw<NotFoundException>();
+        undefined.GetEnumMemberValue(throwIfNotFound: false).ShouldBeNull();
+        Should.Throw<NotFoundException>(static () => undefined.GetEnumMemberValue(throwIfNotFound: true));
     }
 
 
     [TestMethod]
     public void GetLabel()
     {
-        TEnum.Zero.GetLabel(0, throwIfNotFound: false).Should().Be("ぜろ");
-        TEnum.Zero.GetLabel(0, throwIfNotFound: true).Should().Be("ぜろ");
-        TEnum.Zero.GetLabel(1, throwIfNotFound: false).Should().Be("零");
-        TEnum.Zero.GetLabel(1, throwIfNotFound: true).Should().Be("零");
+        TEnum.Zero.GetLabel(0, throwIfNotFound: false).ShouldBe("ぜろ");
+        TEnum.Zero.GetLabel(0, throwIfNotFound: true).ShouldBe("ぜろ");
+        TEnum.Zero.GetLabel(1, throwIfNotFound: false).ShouldBe("零");
+        TEnum.Zero.GetLabel(1, throwIfNotFound: true).ShouldBe("零");
 
-        TEnum.One.GetLabel(0, throwIfNotFound: false).Should().Be("いち");
-        TEnum.One.GetLabel(0, throwIfNotFound: true).Should().Be("いち");
-        TEnum.One.GetLabel(1, throwIfNotFound: false).Should().Be("壱");
-        TEnum.One.GetLabel(1, throwIfNotFound: true).Should().Be("壱");
+        TEnum.One.GetLabel(0, throwIfNotFound: false).ShouldBe("いち");
+        TEnum.One.GetLabel(0, throwIfNotFound: true).ShouldBe("いち");
+        TEnum.One.GetLabel(1, throwIfNotFound: false).ShouldBe("壱");
+        TEnum.One.GetLabel(1, throwIfNotFound: true).ShouldBe("壱");
 
-        TEnum.Two.GetLabel(0, throwIfNotFound: false).Should().BeNull();
-        FluentActions
-            .Invoking(static () => TEnum.Two.GetLabel(0, throwIfNotFound: true))
-            .Should()
-            .Throw<NotFoundException>();
+        TEnum.Two.GetLabel(0, throwIfNotFound: false).ShouldBeNull();
+        Should.Throw<NotFoundException>(static () => TEnum.Two.GetLabel(0, throwIfNotFound: true));
 
-        TEnum.Four.GetLabel(2, throwIfNotFound: false).Should().BeNull();
-        TEnum.Four.GetLabel(2, throwIfNotFound: true).Should().BeNull();
+        TEnum.Four.GetLabel(2, throwIfNotFound: false).ShouldBeNull();
+        TEnum.Four.GetLabel(2, throwIfNotFound: true).ShouldBeNull();
 
         const TEnum undefined = (TEnum)123;
-        undefined.GetLabel(0, throwIfNotFound: false).Should().BeNull();
-        FluentActions
-            .Invoking(static () => undefined.GetLabel(0, throwIfNotFound: true))
-            .Should()
-            .Throw<NotFoundException>();
+        undefined.GetLabel(0, throwIfNotFound: false).ShouldBeNull();
+        Should.Throw<NotFoundException>(static () => undefined.GetLabel(0, throwIfNotFound: true));
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/BasicTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/BasicTests.cs
@@ -9,8 +9,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
 
@@ -21,7 +21,7 @@ public sealed class BasicSByteTests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<SByteEnum>().Should().Be<sbyte>();
+        => FastEnum.GetUnderlyingType<SByteEnum>().ShouldBe(typeof(sbyte));
 
 
     [TestMethod]
@@ -29,7 +29,7 @@ public sealed class BasicSByteTests
     {
         var expect = Enum.GetValues<SByteEnum>();
         var actual = FastEnum.GetValues<SByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -38,7 +38,7 @@ public sealed class BasicSByteTests
     {
         var expect = Enum.GetNames<SByteEnum>();
         var actual = FastEnum.GetNames<SByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -50,16 +50,16 @@ public sealed class BasicSByteTests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const SByteEnum undefined = (SByteEnum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -79,19 +79,19 @@ public sealed class BasicSByteTests
             .ToArray();
         var actual = FastEnum.GetMembers<SByteEnum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -105,21 +105,21 @@ public sealed class BasicSByteTests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const SByteEnum undefined = (SByteEnum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -139,8 +139,8 @@ public sealed class BasicSByteTests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<SByteEnum>();
-        min.Should().NotBeNull();
-        min.Should().Be(SByteEnum.MinValue);
+        min.ShouldNotBeNull();
+        min.ShouldBe(SByteEnum.MinValue);
     }
 
 
@@ -148,46 +148,46 @@ public sealed class BasicSByteTests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<SByteEnum>();
-        max.Should().NotBeNull();
-        max.Should().Be(SByteEnum.MaxValue);
+        max.ShouldNotBeNull();
+        max.ShouldBe(SByteEnum.MaxValue);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<SByteEnum>().Should().Be(false);
+        => FastEnum.IsEmpty<SByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<SByteEnum>().Should().Be(false);
+        => FastEnum.IsContinuous<SByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<SByteEnum>().Should().Be(false);
+        => FastEnum.IsFlags<SByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<SByteEnum>(SByteEnum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum>(SByteEnum.Zero).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum>(SByteEnum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum>((SByteEnum)123).Should().BeFalse();
+        FastEnum.IsDefined<SByteEnum>(SByteEnum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum>(SByteEnum.Zero).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum>(SByteEnum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum>((SByteEnum)123).ShouldBeFalse();
 
         //--- Extension methods
-        SByteEnum.MinValue.IsDefined().Should().BeTrue();
-        SByteEnum.Zero.IsDefined().Should().BeTrue();
-        SByteEnum.MaxValue.IsDefined().Should().BeTrue();
+        SByteEnum.MinValue.IsDefined().ShouldBeTrue();
+        SByteEnum.Zero.IsDefined().ShouldBeTrue();
+        SByteEnum.MaxValue.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<SByteEnum>(nameof(SByteEnum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum>(nameof(SByteEnum.Zero)).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum>(nameof(SByteEnum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<SByteEnum>("123").Should().BeFalse();
-        FastEnum.IsDefined<SByteEnum>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<SByteEnum>(nameof(SByteEnum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum>(nameof(SByteEnum.Zero)).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum>(nameof(SByteEnum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<SByteEnum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<SByteEnum>("minvalue").ShouldBeFalse();
     }
 
 
@@ -204,18 +204,18 @@ public sealed class BasicSByteTests
         foreach (var x in parameters)
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<SByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<SByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SByteEnum>("123", ignoreCase).Should().Be((SByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<SByteEnum>("123", ignoreCase).ShouldBe((SByteEnum)123);
     }
 
 
@@ -232,18 +232,18 @@ public sealed class BasicSByteTests
         foreach (var x in parameters)
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SByteEnum>("123", ignoreCase).Should().Be((SByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<SByteEnum>("123", ignoreCase).ShouldBe((SByteEnum)123);
     }
 
 
@@ -261,27 +261,27 @@ public sealed class BasicSByteTests
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<SByteEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SByteEnum)123);
+        FastEnum.TryParse<SByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SByteEnum)123);
     }
 
 
@@ -299,30 +299,30 @@ public sealed class BasicSByteTests
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<SByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<SByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SByteEnum)123);
+        FastEnum.TryParse<SByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SByteEnum)123);
     }
 
 
@@ -335,20 +335,20 @@ public sealed class BasicSByteTests
         var member = value.ToMember()!;
         var info = typeof(SByteEnum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        SByteEnum.MinValue.ToName().Should().Be(nameof(SByteEnum.MinValue));
-        SByteEnum.Zero.ToName().Should().Be(nameof(SByteEnum.Zero));
-        SByteEnum.MaxValue.ToName().Should().Be(nameof(SByteEnum.MaxValue));
+        SByteEnum.MinValue.ToName().ShouldBe(nameof(SByteEnum.MinValue));
+        SByteEnum.Zero.ToName().ShouldBe(nameof(SByteEnum.Zero));
+        SByteEnum.MaxValue.ToName().ShouldBe(nameof(SByteEnum.MaxValue));
     }
 
 
@@ -358,14 +358,14 @@ public sealed class BasicSByteTests
         var @enum = SByteEnum.MinValue;
         var value = sbyte.MinValue;
 
-        @enum.ToSByte().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        @enum.ToSByte().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -378,7 +378,7 @@ public sealed class BasicSByteTests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -390,7 +390,7 @@ public sealed class BasicByteTests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<ByteEnum>().Should().Be<byte>();
+        => FastEnum.GetUnderlyingType<ByteEnum>().ShouldBe(typeof(byte));
 
 
     [TestMethod]
@@ -398,7 +398,7 @@ public sealed class BasicByteTests
     {
         var expect = Enum.GetValues<ByteEnum>();
         var actual = FastEnum.GetValues<ByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -407,7 +407,7 @@ public sealed class BasicByteTests
     {
         var expect = Enum.GetNames<ByteEnum>();
         var actual = FastEnum.GetNames<ByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -419,16 +419,16 @@ public sealed class BasicByteTests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const ByteEnum undefined = (ByteEnum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -448,19 +448,19 @@ public sealed class BasicByteTests
             .ToArray();
         var actual = FastEnum.GetMembers<ByteEnum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -474,21 +474,21 @@ public sealed class BasicByteTests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const ByteEnum undefined = (ByteEnum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -508,8 +508,8 @@ public sealed class BasicByteTests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<ByteEnum>();
-        min.Should().NotBeNull();
-        min.Should().Be(ByteEnum.MinValue);
+        min.ShouldNotBeNull();
+        min.ShouldBe(ByteEnum.MinValue);
     }
 
 
@@ -517,43 +517,43 @@ public sealed class BasicByteTests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<ByteEnum>();
-        max.Should().NotBeNull();
-        max.Should().Be(ByteEnum.MaxValue);
+        max.ShouldNotBeNull();
+        max.ShouldBe(ByteEnum.MaxValue);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<ByteEnum>().Should().Be(false);
+        => FastEnum.IsEmpty<ByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<ByteEnum>().Should().Be(false);
+        => FastEnum.IsContinuous<ByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<ByteEnum>().Should().Be(false);
+        => FastEnum.IsFlags<ByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<ByteEnum>(ByteEnum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<ByteEnum>(ByteEnum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<ByteEnum>((ByteEnum)123).Should().BeFalse();
+        FastEnum.IsDefined<ByteEnum>(ByteEnum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<ByteEnum>(ByteEnum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<ByteEnum>((ByteEnum)123).ShouldBeFalse();
 
         //--- Extension methods
-        ByteEnum.MinValue.IsDefined().Should().BeTrue();
-        ByteEnum.MaxValue.IsDefined().Should().BeTrue();
+        ByteEnum.MinValue.IsDefined().ShouldBeTrue();
+        ByteEnum.MaxValue.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<ByteEnum>(nameof(ByteEnum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<ByteEnum>(nameof(ByteEnum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<ByteEnum>("123").Should().BeFalse();
-        FastEnum.IsDefined<ByteEnum>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<ByteEnum>(nameof(ByteEnum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<ByteEnum>(nameof(ByteEnum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<ByteEnum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<ByteEnum>("minvalue").ShouldBeFalse();
     }
 
 
@@ -569,18 +569,18 @@ public sealed class BasicByteTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<ByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ByteEnum>("123", ignoreCase).Should().Be((ByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ByteEnum>("123", ignoreCase).ShouldBe((ByteEnum)123);
     }
 
 
@@ -596,18 +596,18 @@ public sealed class BasicByteTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ByteEnum>("123", ignoreCase).Should().Be((ByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ByteEnum>("123", ignoreCase).ShouldBe((ByteEnum)123);
     }
 
 
@@ -624,27 +624,27 @@ public sealed class BasicByteTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<ByteEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ByteEnum)123);
+        FastEnum.TryParse<ByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ByteEnum)123);
     }
 
 
@@ -661,30 +661,30 @@ public sealed class BasicByteTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<ByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<ByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ByteEnum)123);
+        FastEnum.TryParse<ByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ByteEnum)123);
     }
 
 
@@ -697,19 +697,19 @@ public sealed class BasicByteTests
         var member = value.ToMember()!;
         var info = typeof(ByteEnum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        ByteEnum.MinValue.ToName().Should().Be(nameof(ByteEnum.MinValue));
-        ByteEnum.MaxValue.ToName().Should().Be(nameof(ByteEnum.MaxValue));
+        ByteEnum.MinValue.ToName().ShouldBe(nameof(ByteEnum.MinValue));
+        ByteEnum.MaxValue.ToName().ShouldBe(nameof(ByteEnum.MaxValue));
     }
 
 
@@ -719,14 +719,14 @@ public sealed class BasicByteTests
         var @enum = ByteEnum.MinValue;
         var value = byte.MinValue;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        @enum.ToByte().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        @enum.ToByte().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -739,7 +739,7 @@ public sealed class BasicByteTests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -751,7 +751,7 @@ public sealed class BasicInt16Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<Int16Enum>().Should().Be<short>();
+        => FastEnum.GetUnderlyingType<Int16Enum>().ShouldBe(typeof(short));
 
 
     [TestMethod]
@@ -759,7 +759,7 @@ public sealed class BasicInt16Tests
     {
         var expect = Enum.GetValues<Int16Enum>();
         var actual = FastEnum.GetValues<Int16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -768,7 +768,7 @@ public sealed class BasicInt16Tests
     {
         var expect = Enum.GetNames<Int16Enum>();
         var actual = FastEnum.GetNames<Int16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -780,16 +780,16 @@ public sealed class BasicInt16Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const Int16Enum undefined = (Int16Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -809,19 +809,19 @@ public sealed class BasicInt16Tests
             .ToArray();
         var actual = FastEnum.GetMembers<Int16Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -835,21 +835,21 @@ public sealed class BasicInt16Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const Int16Enum undefined = (Int16Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -869,8 +869,8 @@ public sealed class BasicInt16Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<Int16Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(Int16Enum.MinValue);
+        min.ShouldNotBeNull();
+        min.ShouldBe(Int16Enum.MinValue);
     }
 
 
@@ -878,46 +878,46 @@ public sealed class BasicInt16Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<Int16Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(Int16Enum.MaxValue);
+        max.ShouldNotBeNull();
+        max.ShouldBe(Int16Enum.MaxValue);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<Int16Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<Int16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<Int16Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<Int16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<Int16Enum>().Should().Be(false);
+        => FastEnum.IsFlags<Int16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<Int16Enum>(Int16Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum>(Int16Enum.Zero).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum>(Int16Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum>((Int16Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<Int16Enum>(Int16Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum>(Int16Enum.Zero).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum>(Int16Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum>((Int16Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        Int16Enum.MinValue.IsDefined().Should().BeTrue();
-        Int16Enum.Zero.IsDefined().Should().BeTrue();
-        Int16Enum.MaxValue.IsDefined().Should().BeTrue();
+        Int16Enum.MinValue.IsDefined().ShouldBeTrue();
+        Int16Enum.Zero.IsDefined().ShouldBeTrue();
+        Int16Enum.MaxValue.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<Int16Enum>(nameof(Int16Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum>(nameof(Int16Enum.Zero)).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum>(nameof(Int16Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int16Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<Int16Enum>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<Int16Enum>(nameof(Int16Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum>(nameof(Int16Enum.Zero)).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum>(nameof(Int16Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int16Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<Int16Enum>("minvalue").ShouldBeFalse();
     }
 
 
@@ -934,18 +934,18 @@ public sealed class BasicInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<Int16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<Int16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int16Enum>("123", ignoreCase).Should().Be((Int16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int16Enum>("123", ignoreCase).ShouldBe((Int16Enum)123);
     }
 
 
@@ -962,18 +962,18 @@ public sealed class BasicInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int16Enum>("123", ignoreCase).Should().Be((Int16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int16Enum>("123", ignoreCase).ShouldBe((Int16Enum)123);
     }
 
 
@@ -991,27 +991,27 @@ public sealed class BasicInt16Tests
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<Int16Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int16Enum)123);
+        FastEnum.TryParse<Int16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int16Enum)123);
     }
 
 
@@ -1029,30 +1029,30 @@ public sealed class BasicInt16Tests
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<Int16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int16Enum)123);
+        FastEnum.TryParse<Int16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int16Enum)123);
     }
 
 
@@ -1065,20 +1065,20 @@ public sealed class BasicInt16Tests
         var member = value.ToMember()!;
         var info = typeof(Int16Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        Int16Enum.MinValue.ToName().Should().Be(nameof(Int16Enum.MinValue));
-        Int16Enum.Zero.ToName().Should().Be(nameof(Int16Enum.Zero));
-        Int16Enum.MaxValue.ToName().Should().Be(nameof(Int16Enum.MaxValue));
+        Int16Enum.MinValue.ToName().ShouldBe(nameof(Int16Enum.MinValue));
+        Int16Enum.Zero.ToName().ShouldBe(nameof(Int16Enum.Zero));
+        Int16Enum.MaxValue.ToName().ShouldBe(nameof(Int16Enum.MaxValue));
     }
 
 
@@ -1088,14 +1088,14 @@ public sealed class BasicInt16Tests
         var @enum = Int16Enum.MinValue;
         var value = short.MinValue;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        @enum.ToInt16().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        @enum.ToInt16().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -1108,7 +1108,7 @@ public sealed class BasicInt16Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1120,7 +1120,7 @@ public sealed class BasicUInt16Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<UInt16Enum>().Should().Be<ushort>();
+        => FastEnum.GetUnderlyingType<UInt16Enum>().ShouldBe(typeof(ushort));
 
 
     [TestMethod]
@@ -1128,7 +1128,7 @@ public sealed class BasicUInt16Tests
     {
         var expect = Enum.GetValues<UInt16Enum>();
         var actual = FastEnum.GetValues<UInt16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1137,7 +1137,7 @@ public sealed class BasicUInt16Tests
     {
         var expect = Enum.GetNames<UInt16Enum>();
         var actual = FastEnum.GetNames<UInt16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1149,16 +1149,16 @@ public sealed class BasicUInt16Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const UInt16Enum undefined = (UInt16Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1178,19 +1178,19 @@ public sealed class BasicUInt16Tests
             .ToArray();
         var actual = FastEnum.GetMembers<UInt16Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -1204,21 +1204,21 @@ public sealed class BasicUInt16Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const UInt16Enum undefined = (UInt16Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -1238,8 +1238,8 @@ public sealed class BasicUInt16Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<UInt16Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(UInt16Enum.MinValue);
+        min.ShouldNotBeNull();
+        min.ShouldBe(UInt16Enum.MinValue);
     }
 
 
@@ -1247,43 +1247,43 @@ public sealed class BasicUInt16Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<UInt16Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(UInt16Enum.MaxValue);
+        max.ShouldNotBeNull();
+        max.ShouldBe(UInt16Enum.MaxValue);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<UInt16Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<UInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<UInt16Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<UInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<UInt16Enum>().Should().Be(false);
+        => FastEnum.IsFlags<UInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<UInt16Enum>(UInt16Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt16Enum>(UInt16Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt16Enum>((UInt16Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<UInt16Enum>(UInt16Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt16Enum>(UInt16Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt16Enum>((UInt16Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        UInt16Enum.MinValue.IsDefined().Should().BeTrue();
-        UInt16Enum.MaxValue.IsDefined().Should().BeTrue();
+        UInt16Enum.MinValue.IsDefined().ShouldBeTrue();
+        UInt16Enum.MaxValue.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<UInt16Enum>(nameof(UInt16Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt16Enum>(nameof(UInt16Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt16Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<UInt16Enum>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<UInt16Enum>(nameof(UInt16Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt16Enum>(nameof(UInt16Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt16Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<UInt16Enum>("minvalue").ShouldBeFalse();
     }
 
 
@@ -1299,18 +1299,18 @@ public sealed class BasicUInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<UInt16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<UInt16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt16Enum>("123", ignoreCase).Should().Be((UInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt16Enum>("123", ignoreCase).ShouldBe((UInt16Enum)123);
     }
 
 
@@ -1326,18 +1326,18 @@ public sealed class BasicUInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt16Enum>("123", ignoreCase).Should().Be((UInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt16Enum>("123", ignoreCase).ShouldBe((UInt16Enum)123);
     }
 
 
@@ -1354,27 +1354,27 @@ public sealed class BasicUInt16Tests
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<UInt16Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt16Enum)123);
+        FastEnum.TryParse<UInt16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt16Enum)123);
     }
 
 
@@ -1391,30 +1391,30 @@ public sealed class BasicUInt16Tests
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<UInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt16Enum)123);
+        FastEnum.TryParse<UInt16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt16Enum)123);
     }
 
 
@@ -1427,19 +1427,19 @@ public sealed class BasicUInt16Tests
         var member = value.ToMember()!;
         var info = typeof(UInt16Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        UInt16Enum.MinValue.ToName().Should().Be(nameof(UInt16Enum.MinValue));
-        UInt16Enum.MaxValue.ToName().Should().Be(nameof(UInt16Enum.MaxValue));
+        UInt16Enum.MinValue.ToName().ShouldBe(nameof(UInt16Enum.MinValue));
+        UInt16Enum.MaxValue.ToName().ShouldBe(nameof(UInt16Enum.MaxValue));
     }
 
 
@@ -1449,14 +1449,14 @@ public sealed class BasicUInt16Tests
         var @enum = UInt16Enum.MinValue;
         var value = ushort.MinValue;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        @enum.ToUInt16().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        @enum.ToUInt16().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -1469,7 +1469,7 @@ public sealed class BasicUInt16Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1481,7 +1481,7 @@ public sealed class BasicInt32Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<Int32Enum>().Should().Be<int>();
+        => FastEnum.GetUnderlyingType<Int32Enum>().ShouldBe(typeof(int));
 
 
     [TestMethod]
@@ -1489,7 +1489,7 @@ public sealed class BasicInt32Tests
     {
         var expect = Enum.GetValues<Int32Enum>();
         var actual = FastEnum.GetValues<Int32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1498,7 +1498,7 @@ public sealed class BasicInt32Tests
     {
         var expect = Enum.GetNames<Int32Enum>();
         var actual = FastEnum.GetNames<Int32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1510,16 +1510,16 @@ public sealed class BasicInt32Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const Int32Enum undefined = (Int32Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1539,19 +1539,19 @@ public sealed class BasicInt32Tests
             .ToArray();
         var actual = FastEnum.GetMembers<Int32Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -1565,21 +1565,21 @@ public sealed class BasicInt32Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const Int32Enum undefined = (Int32Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -1599,8 +1599,8 @@ public sealed class BasicInt32Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<Int32Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(Int32Enum.MinValue);
+        min.ShouldNotBeNull();
+        min.ShouldBe(Int32Enum.MinValue);
     }
 
 
@@ -1608,46 +1608,46 @@ public sealed class BasicInt32Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<Int32Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(Int32Enum.MaxValue);
+        max.ShouldNotBeNull();
+        max.ShouldBe(Int32Enum.MaxValue);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<Int32Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<Int32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<Int32Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<Int32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<Int32Enum>().Should().Be(false);
+        => FastEnum.IsFlags<Int32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<Int32Enum>(Int32Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum>(Int32Enum.Zero).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum>(Int32Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum>((Int32Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<Int32Enum>(Int32Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum>(Int32Enum.Zero).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum>(Int32Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum>((Int32Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        Int32Enum.MinValue.IsDefined().Should().BeTrue();
-        Int32Enum.Zero.IsDefined().Should().BeTrue();
-        Int32Enum.MaxValue.IsDefined().Should().BeTrue();
+        Int32Enum.MinValue.IsDefined().ShouldBeTrue();
+        Int32Enum.Zero.IsDefined().ShouldBeTrue();
+        Int32Enum.MaxValue.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<Int32Enum>(nameof(Int32Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum>(nameof(Int32Enum.Zero)).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum>(nameof(Int32Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int32Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<Int32Enum>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<Int32Enum>(nameof(Int32Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum>(nameof(Int32Enum.Zero)).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum>(nameof(Int32Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int32Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<Int32Enum>("minvalue").ShouldBeFalse();
     }
 
 
@@ -1664,18 +1664,18 @@ public sealed class BasicInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<Int32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<Int32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int32Enum>("123", ignoreCase).Should().Be((Int32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int32Enum>("123", ignoreCase).ShouldBe((Int32Enum)123);
     }
 
 
@@ -1692,18 +1692,18 @@ public sealed class BasicInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int32Enum>("123", ignoreCase).Should().Be((Int32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int32Enum>("123", ignoreCase).ShouldBe((Int32Enum)123);
     }
 
 
@@ -1721,27 +1721,27 @@ public sealed class BasicInt32Tests
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<Int32Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int32Enum)123);
+        FastEnum.TryParse<Int32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int32Enum)123);
     }
 
 
@@ -1759,30 +1759,30 @@ public sealed class BasicInt32Tests
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<Int32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int32Enum)123);
+        FastEnum.TryParse<Int32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int32Enum)123);
     }
 
 
@@ -1795,20 +1795,20 @@ public sealed class BasicInt32Tests
         var member = value.ToMember()!;
         var info = typeof(Int32Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        Int32Enum.MinValue.ToName().Should().Be(nameof(Int32Enum.MinValue));
-        Int32Enum.Zero.ToName().Should().Be(nameof(Int32Enum.Zero));
-        Int32Enum.MaxValue.ToName().Should().Be(nameof(Int32Enum.MaxValue));
+        Int32Enum.MinValue.ToName().ShouldBe(nameof(Int32Enum.MinValue));
+        Int32Enum.Zero.ToName().ShouldBe(nameof(Int32Enum.Zero));
+        Int32Enum.MaxValue.ToName().ShouldBe(nameof(Int32Enum.MaxValue));
     }
 
 
@@ -1818,14 +1818,14 @@ public sealed class BasicInt32Tests
         var @enum = Int32Enum.MinValue;
         var value = int.MinValue;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        @enum.ToInt32().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        @enum.ToInt32().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -1838,7 +1838,7 @@ public sealed class BasicInt32Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1850,7 +1850,7 @@ public sealed class BasicUInt32Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<UInt32Enum>().Should().Be<uint>();
+        => FastEnum.GetUnderlyingType<UInt32Enum>().ShouldBe(typeof(uint));
 
 
     [TestMethod]
@@ -1858,7 +1858,7 @@ public sealed class BasicUInt32Tests
     {
         var expect = Enum.GetValues<UInt32Enum>();
         var actual = FastEnum.GetValues<UInt32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1867,7 +1867,7 @@ public sealed class BasicUInt32Tests
     {
         var expect = Enum.GetNames<UInt32Enum>();
         var actual = FastEnum.GetNames<UInt32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1879,16 +1879,16 @@ public sealed class BasicUInt32Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const UInt32Enum undefined = (UInt32Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1908,19 +1908,19 @@ public sealed class BasicUInt32Tests
             .ToArray();
         var actual = FastEnum.GetMembers<UInt32Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -1934,21 +1934,21 @@ public sealed class BasicUInt32Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const UInt32Enum undefined = (UInt32Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -1968,8 +1968,8 @@ public sealed class BasicUInt32Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<UInt32Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(UInt32Enum.MinValue);
+        min.ShouldNotBeNull();
+        min.ShouldBe(UInt32Enum.MinValue);
     }
 
 
@@ -1977,43 +1977,43 @@ public sealed class BasicUInt32Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<UInt32Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(UInt32Enum.MaxValue);
+        max.ShouldNotBeNull();
+        max.ShouldBe(UInt32Enum.MaxValue);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<UInt32Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<UInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<UInt32Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<UInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<UInt32Enum>().Should().Be(false);
+        => FastEnum.IsFlags<UInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<UInt32Enum>(UInt32Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt32Enum>(UInt32Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt32Enum>((UInt32Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<UInt32Enum>(UInt32Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt32Enum>(UInt32Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt32Enum>((UInt32Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        UInt32Enum.MinValue.IsDefined().Should().BeTrue();
-        UInt32Enum.MaxValue.IsDefined().Should().BeTrue();
+        UInt32Enum.MinValue.IsDefined().ShouldBeTrue();
+        UInt32Enum.MaxValue.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<UInt32Enum>(nameof(UInt32Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt32Enum>(nameof(UInt32Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt32Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<UInt32Enum>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<UInt32Enum>(nameof(UInt32Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt32Enum>(nameof(UInt32Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt32Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<UInt32Enum>("minvalue").ShouldBeFalse();
     }
 
 
@@ -2029,18 +2029,18 @@ public sealed class BasicUInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<UInt32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<UInt32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt32Enum>("123", ignoreCase).Should().Be((UInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt32Enum>("123", ignoreCase).ShouldBe((UInt32Enum)123);
     }
 
 
@@ -2056,18 +2056,18 @@ public sealed class BasicUInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt32Enum>("123", ignoreCase).Should().Be((UInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt32Enum>("123", ignoreCase).ShouldBe((UInt32Enum)123);
     }
 
 
@@ -2084,27 +2084,27 @@ public sealed class BasicUInt32Tests
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<UInt32Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt32Enum)123);
+        FastEnum.TryParse<UInt32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt32Enum)123);
     }
 
 
@@ -2121,30 +2121,30 @@ public sealed class BasicUInt32Tests
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<UInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt32Enum)123);
+        FastEnum.TryParse<UInt32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt32Enum)123);
     }
 
 
@@ -2157,19 +2157,19 @@ public sealed class BasicUInt32Tests
         var member = value.ToMember()!;
         var info = typeof(UInt32Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        UInt32Enum.MinValue.ToName().Should().Be(nameof(UInt32Enum.MinValue));
-        UInt32Enum.MaxValue.ToName().Should().Be(nameof(UInt32Enum.MaxValue));
+        UInt32Enum.MinValue.ToName().ShouldBe(nameof(UInt32Enum.MinValue));
+        UInt32Enum.MaxValue.ToName().ShouldBe(nameof(UInt32Enum.MaxValue));
     }
 
 
@@ -2179,14 +2179,14 @@ public sealed class BasicUInt32Tests
         var @enum = UInt32Enum.MinValue;
         var value = uint.MinValue;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        @enum.ToUInt32().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        @enum.ToUInt32().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -2199,7 +2199,7 @@ public sealed class BasicUInt32Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -2211,7 +2211,7 @@ public sealed class BasicInt64Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<Int64Enum>().Should().Be<long>();
+        => FastEnum.GetUnderlyingType<Int64Enum>().ShouldBe(typeof(long));
 
 
     [TestMethod]
@@ -2219,7 +2219,7 @@ public sealed class BasicInt64Tests
     {
         var expect = Enum.GetValues<Int64Enum>();
         var actual = FastEnum.GetValues<Int64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2228,7 +2228,7 @@ public sealed class BasicInt64Tests
     {
         var expect = Enum.GetNames<Int64Enum>();
         var actual = FastEnum.GetNames<Int64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2240,16 +2240,16 @@ public sealed class BasicInt64Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const Int64Enum undefined = (Int64Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -2269,19 +2269,19 @@ public sealed class BasicInt64Tests
             .ToArray();
         var actual = FastEnum.GetMembers<Int64Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -2295,21 +2295,21 @@ public sealed class BasicInt64Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const Int64Enum undefined = (Int64Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -2329,8 +2329,8 @@ public sealed class BasicInt64Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<Int64Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(Int64Enum.MinValue);
+        min.ShouldNotBeNull();
+        min.ShouldBe(Int64Enum.MinValue);
     }
 
 
@@ -2338,46 +2338,46 @@ public sealed class BasicInt64Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<Int64Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(Int64Enum.MaxValue);
+        max.ShouldNotBeNull();
+        max.ShouldBe(Int64Enum.MaxValue);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<Int64Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<Int64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<Int64Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<Int64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<Int64Enum>().Should().Be(false);
+        => FastEnum.IsFlags<Int64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<Int64Enum>(Int64Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum>(Int64Enum.Zero).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum>(Int64Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum>((Int64Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<Int64Enum>(Int64Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum>(Int64Enum.Zero).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum>(Int64Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum>((Int64Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        Int64Enum.MinValue.IsDefined().Should().BeTrue();
-        Int64Enum.Zero.IsDefined().Should().BeTrue();
-        Int64Enum.MaxValue.IsDefined().Should().BeTrue();
+        Int64Enum.MinValue.IsDefined().ShouldBeTrue();
+        Int64Enum.Zero.IsDefined().ShouldBeTrue();
+        Int64Enum.MaxValue.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<Int64Enum>(nameof(Int64Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum>(nameof(Int64Enum.Zero)).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum>(nameof(Int64Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<Int64Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<Int64Enum>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<Int64Enum>(nameof(Int64Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum>(nameof(Int64Enum.Zero)).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum>(nameof(Int64Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<Int64Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<Int64Enum>("minvalue").ShouldBeFalse();
     }
 
 
@@ -2394,18 +2394,18 @@ public sealed class BasicInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<Int64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<Int64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int64Enum>("123", ignoreCase).Should().Be((Int64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int64Enum>("123", ignoreCase).ShouldBe((Int64Enum)123);
     }
 
 
@@ -2422,18 +2422,18 @@ public sealed class BasicInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<Int64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<Int64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<Int64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<Int64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<Int64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<Int64Enum>("123", ignoreCase).Should().Be((Int64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<Int64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<Int64Enum>("123", ignoreCase).ShouldBe((Int64Enum)123);
     }
 
 
@@ -2451,27 +2451,27 @@ public sealed class BasicInt64Tests
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<Int64Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int64Enum)123);
+        FastEnum.TryParse<Int64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int64Enum)123);
     }
 
 
@@ -2489,30 +2489,30 @@ public sealed class BasicInt64Tests
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<Int64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<Int64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<Int64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<Int64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<Int64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((Int64Enum)123);
+        FastEnum.TryParse<Int64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<Int64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((Int64Enum)123);
     }
 
 
@@ -2525,20 +2525,20 @@ public sealed class BasicInt64Tests
         var member = value.ToMember()!;
         var info = typeof(Int64Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        Int64Enum.MinValue.ToName().Should().Be(nameof(Int64Enum.MinValue));
-        Int64Enum.Zero.ToName().Should().Be(nameof(Int64Enum.Zero));
-        Int64Enum.MaxValue.ToName().Should().Be(nameof(Int64Enum.MaxValue));
+        Int64Enum.MinValue.ToName().ShouldBe(nameof(Int64Enum.MinValue));
+        Int64Enum.Zero.ToName().ShouldBe(nameof(Int64Enum.Zero));
+        Int64Enum.MaxValue.ToName().ShouldBe(nameof(Int64Enum.MaxValue));
     }
 
 
@@ -2548,14 +2548,14 @@ public sealed class BasicInt64Tests
         var @enum = Int64Enum.MinValue;
         var value = long.MinValue;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        @enum.ToInt64().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        @enum.ToInt64().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -2568,7 +2568,7 @@ public sealed class BasicInt64Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -2580,7 +2580,7 @@ public sealed class BasicUInt64Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<UInt64Enum>().Should().Be<ulong>();
+        => FastEnum.GetUnderlyingType<UInt64Enum>().ShouldBe(typeof(ulong));
 
 
     [TestMethod]
@@ -2588,7 +2588,7 @@ public sealed class BasicUInt64Tests
     {
         var expect = Enum.GetValues<UInt64Enum>();
         var actual = FastEnum.GetValues<UInt64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2597,7 +2597,7 @@ public sealed class BasicUInt64Tests
     {
         var expect = Enum.GetNames<UInt64Enum>();
         var actual = FastEnum.GetNames<UInt64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2609,16 +2609,16 @@ public sealed class BasicUInt64Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const UInt64Enum undefined = (UInt64Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -2638,19 +2638,19 @@ public sealed class BasicUInt64Tests
             .ToArray();
         var actual = FastEnum.GetMembers<UInt64Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -2664,21 +2664,21 @@ public sealed class BasicUInt64Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const UInt64Enum undefined = (UInt64Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -2698,8 +2698,8 @@ public sealed class BasicUInt64Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<UInt64Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(UInt64Enum.MinValue);
+        min.ShouldNotBeNull();
+        min.ShouldBe(UInt64Enum.MinValue);
     }
 
 
@@ -2707,43 +2707,43 @@ public sealed class BasicUInt64Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<UInt64Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(UInt64Enum.MaxValue);
+        max.ShouldNotBeNull();
+        max.ShouldBe(UInt64Enum.MaxValue);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<UInt64Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<UInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<UInt64Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<UInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<UInt64Enum>().Should().Be(false);
+        => FastEnum.IsFlags<UInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<UInt64Enum>(UInt64Enum.MinValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt64Enum>(UInt64Enum.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<UInt64Enum>((UInt64Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<UInt64Enum>(UInt64Enum.MinValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt64Enum>(UInt64Enum.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<UInt64Enum>((UInt64Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        UInt64Enum.MinValue.IsDefined().Should().BeTrue();
-        UInt64Enum.MaxValue.IsDefined().Should().BeTrue();
+        UInt64Enum.MinValue.IsDefined().ShouldBeTrue();
+        UInt64Enum.MaxValue.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<UInt64Enum>(nameof(UInt64Enum.MinValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt64Enum>(nameof(UInt64Enum.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<UInt64Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<UInt64Enum>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<UInt64Enum>(nameof(UInt64Enum.MinValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt64Enum>(nameof(UInt64Enum.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<UInt64Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<UInt64Enum>("minvalue").ShouldBeFalse();
     }
 
 
@@ -2759,18 +2759,18 @@ public sealed class BasicUInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<UInt64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<UInt64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt64Enum>("123", ignoreCase).Should().Be((UInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt64Enum>("123", ignoreCase).ShouldBe((UInt64Enum)123);
     }
 
 
@@ -2786,18 +2786,18 @@ public sealed class BasicUInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<UInt64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<UInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<UInt64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<UInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<UInt64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<UInt64Enum>("123", ignoreCase).Should().Be((UInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<UInt64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<UInt64Enum>("123", ignoreCase).ShouldBe((UInt64Enum)123);
     }
 
 
@@ -2814,27 +2814,27 @@ public sealed class BasicUInt64Tests
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<UInt64Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt64Enum)123);
+        FastEnum.TryParse<UInt64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt64Enum)123);
     }
 
 
@@ -2851,30 +2851,30 @@ public sealed class BasicUInt64Tests
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<UInt64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<UInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<UInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<UInt64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<UInt64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((UInt64Enum)123);
+        FastEnum.TryParse<UInt64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<UInt64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((UInt64Enum)123);
     }
 
 
@@ -2887,19 +2887,19 @@ public sealed class BasicUInt64Tests
         var member = value.ToMember()!;
         var info = typeof(UInt64Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        UInt64Enum.MinValue.ToName().Should().Be(nameof(UInt64Enum.MinValue));
-        UInt64Enum.MaxValue.ToName().Should().Be(nameof(UInt64Enum.MaxValue));
+        UInt64Enum.MinValue.ToName().ShouldBe(nameof(UInt64Enum.MinValue));
+        UInt64Enum.MaxValue.ToName().ShouldBe(nameof(UInt64Enum.MaxValue));
     }
 
 
@@ -2909,14 +2909,14 @@ public sealed class BasicUInt64Tests
         var @enum = UInt64Enum.MinValue;
         var value = ulong.MinValue;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        @enum.ToUInt64().Should().Be(value);
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        @enum.ToUInt64().ShouldBe(value);
     }
 
 
@@ -2929,7 +2929,7 @@ public sealed class BasicUInt64Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/BasicTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/BasicTests.tt
@@ -27,8 +27,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
 
@@ -40,7 +40,7 @@ public sealed class Basic<#= x.AliasType #>Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<<#= x.EnumType #>>().Should().Be<<#= x.UnderlyingType #>>();
+        => FastEnum.GetUnderlyingType<<#= x.EnumType #>>().ShouldBe(typeof(<#= x.UnderlyingType #>));
 
 
     [TestMethod]
@@ -48,7 +48,7 @@ public sealed class Basic<#= x.AliasType #>Tests
     {
         var expect = Enum.GetValues<<#= x.EnumType #>>();
         var actual = FastEnum.GetValues<<#= x.EnumType #>>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -57,7 +57,7 @@ public sealed class Basic<#= x.AliasType #>Tests
     {
         var expect = Enum.GetNames<<#= x.EnumType #>>();
         var actual = FastEnum.GetNames<<#= x.EnumType #>>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -69,16 +69,16 @@ public sealed class Basic<#= x.AliasType #>Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const <#= x.EnumType #> undefined = (<#= x.EnumType #>)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -98,19 +98,19 @@ public sealed class Basic<#= x.AliasType #>Tests
             .ToArray();
         var actual = FastEnum.GetMembers<<#= x.EnumType #>>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -124,21 +124,21 @@ public sealed class Basic<#= x.AliasType #>Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const <#= x.EnumType #> undefined = (<#= x.EnumType #>)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -158,8 +158,8 @@ public sealed class Basic<#= x.AliasType #>Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<<#= x.EnumType #>>();
-        min.Should().NotBeNull();
-        min.Should().Be(<#= x.EnumType #>.MinValue);
+        min.ShouldNotBeNull();
+        min.ShouldBe(<#= x.EnumType #>.MinValue);
     }
 
 
@@ -167,52 +167,52 @@ public sealed class Basic<#= x.AliasType #>Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<<#= x.EnumType #>>();
-        max.Should().NotBeNull();
-        max.Should().Be(<#= x.EnumType #>.MaxValue);
+        max.ShouldNotBeNull();
+        max.ShouldBe(<#= x.EnumType #>.MaxValue);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<<#= x.EnumType #>>().Should().Be(false);
+        => FastEnum.IsEmpty<<#= x.EnumType #>>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<<#= x.EnumType #>>().Should().Be(false);
+        => FastEnum.IsContinuous<<#= x.EnumType #>>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<<#= x.EnumType #>>().Should().Be(false);
+        => FastEnum.IsFlags<<#= x.EnumType #>>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.MinValue).Should().BeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.MinValue).ShouldBeTrue();
 <# if (x.IsSignedType) { #>
-        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.Zero).Should().BeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.Zero).ShouldBeTrue();
 <# } #>
-        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.MaxValue).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>((<#= x.EnumType #>)123).Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.MaxValue).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>((<#= x.EnumType #>)123).ShouldBeFalse();
 
         //--- Extension methods
-        <#= x.EnumType #>.MinValue.IsDefined().Should().BeTrue();
+        <#= x.EnumType #>.MinValue.IsDefined().ShouldBeTrue();
 <# if (x.IsSignedType) { #>
-        <#= x.EnumType #>.Zero.IsDefined().Should().BeTrue();
+        <#= x.EnumType #>.Zero.IsDefined().ShouldBeTrue();
 <# } #>
-        <#= x.EnumType #>.MaxValue.IsDefined().Should().BeTrue();
+        <#= x.EnumType #>.MaxValue.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.MinValue)).Should().BeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.MinValue)).ShouldBeTrue();
 <# if (x.IsSignedType) { #>
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.Zero)).Should().BeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.Zero)).ShouldBeTrue();
 <# } #>
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.MaxValue)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>("123").Should().BeFalse();
-        FastEnum.IsDefined<<#= x.EnumType #>>("minvalue").Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.MaxValue)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>("123").ShouldBeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>("minvalue").ShouldBeFalse();
     }
 
 
@@ -231,18 +231,18 @@ public sealed class Basic<#= x.AliasType #>Tests
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -261,18 +261,18 @@ public sealed class Basic<#= x.AliasType #>Tests
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -292,27 +292,27 @@ public sealed class Basic<#= x.AliasType #>Tests
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -332,30 +332,30 @@ public sealed class Basic<#= x.AliasType #>Tests
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -368,22 +368,22 @@ public sealed class Basic<#= x.AliasType #>Tests
         var member = value.ToMember()!;
         var info = typeof(<#= x.EnumType #>).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        <#= x.EnumType #>.MinValue.ToName().Should().Be(nameof(<#= x.EnumType #>.MinValue));
+        <#= x.EnumType #>.MinValue.ToName().ShouldBe(nameof(<#= x.EnumType #>.MinValue));
 <# if (x.IsSignedType) { #>
-        <#= x.EnumType #>.Zero.ToName().Should().Be(nameof(<#= x.EnumType #>.Zero));
+        <#= x.EnumType #>.Zero.ToName().ShouldBe(nameof(<#= x.EnumType #>.Zero));
 <# } #>
-        <#= x.EnumType #>.MaxValue.ToName().Should().Be(nameof(<#= x.EnumType #>.MaxValue));
+        <#= x.EnumType #>.MaxValue.ToName().ShouldBe(nameof(<#= x.EnumType #>.MaxValue));
     }
 
 
@@ -395,9 +395,9 @@ public sealed class Basic<#= x.AliasType #>Tests
 
 <# foreach (var y in parameters) { #>
 <# if (x.EnumType == y.EnumType) { #>
-        @enum.To<#= y.AliasType #>().Should().Be(value);
+        @enum.To<#= y.AliasType #>().ShouldBe(value);
 <# } else { #>
-        FluentActions.Invoking(() => @enum.To<#= y.AliasType #>()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.To<#= y.AliasType #>());
 <# } #>
 <# } #>
     }
@@ -412,7 +412,7 @@ public sealed class Basic<#= x.AliasType #>Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/CaseInsensitiveTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/CaseInsensitiveTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 using TEnum = FastEnumUtility.UnitTests.Models.CaseInsensitiveEnum;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
@@ -26,14 +26,14 @@ public class CaseInsensitiveTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<TEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<TEnum>(valueString, ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<TEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<TEnum>(valueString, ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<TEnum>("123", ignoreCase).Should().Be((TEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<TEnum>("123", ignoreCase).ShouldBe((TEnum)123);
     }
 
 
@@ -52,14 +52,14 @@ public class CaseInsensitiveTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<TEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<TEnum>(valueString, ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<TEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<TEnum>(valueString, ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<TEnum>("123", ignoreCase).Should().Be((TEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<TEnum>("123", ignoreCase).ShouldBe((TEnum)123);
     }
 
 
@@ -77,19 +77,19 @@ public class CaseInsensitiveTests
         };
         foreach (var x in parameters)
         {
-            FastEnum.TryParse<TEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<TEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.TryParse<TEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<TEnum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
         }
-        FastEnum.TryParse<TEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((TEnum)123);
+        FastEnum.TryParse<TEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((TEnum)123);
     }
 
 
@@ -107,18 +107,18 @@ public class CaseInsensitiveTests
         };
         foreach (var x in parameters)
         {
-            FastEnum.TryParse<TEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<TEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.TryParse<TEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<TEnum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
         }
-        FastEnum.TryParse<TEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((TEnum)123);
+        FastEnum.TryParse<TEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((TEnum)123);
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/ContinuousTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/ContinuousTests.cs
@@ -9,8 +9,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
 
@@ -21,7 +21,7 @@ public sealed class ContinuousSByteTests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<ContinuousSByteEnum>().Should().Be<sbyte>();
+        => FastEnum.GetUnderlyingType<ContinuousSByteEnum>().ShouldBe(typeof(sbyte));
 
 
     [TestMethod]
@@ -29,7 +29,7 @@ public sealed class ContinuousSByteTests
     {
         var expect = Enum.GetValues<ContinuousSByteEnum>();
         var actual = FastEnum.GetValues<ContinuousSByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -38,7 +38,7 @@ public sealed class ContinuousSByteTests
     {
         var expect = Enum.GetNames<ContinuousSByteEnum>();
         var actual = FastEnum.GetNames<ContinuousSByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -50,16 +50,16 @@ public sealed class ContinuousSByteTests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const ContinuousSByteEnum undefined = (ContinuousSByteEnum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -79,19 +79,19 @@ public sealed class ContinuousSByteTests
             .ToArray();
         var actual = FastEnum.GetMembers<ContinuousSByteEnum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -105,21 +105,21 @@ public sealed class ContinuousSByteTests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const ContinuousSByteEnum undefined = (ContinuousSByteEnum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -139,8 +139,8 @@ public sealed class ContinuousSByteTests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<ContinuousSByteEnum>();
-        min.Should().NotBeNull();
-        min.Should().Be(ContinuousSByteEnum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(ContinuousSByteEnum.A);
     }
 
 
@@ -148,50 +148,50 @@ public sealed class ContinuousSByteTests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<ContinuousSByteEnum>();
-        max.Should().NotBeNull();
-        max.Should().Be(ContinuousSByteEnum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(ContinuousSByteEnum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<ContinuousSByteEnum>().Should().Be(false);
+        => FastEnum.IsEmpty<ContinuousSByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<ContinuousSByteEnum>().Should().Be(true);
+        => FastEnum.IsContinuous<ContinuousSByteEnum>().ShouldBe(true);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<ContinuousSByteEnum>().Should().Be(false);
+        => FastEnum.IsFlags<ContinuousSByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<ContinuousSByteEnum>(ContinuousSByteEnum.A).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousSByteEnum>(ContinuousSByteEnum.B).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousSByteEnum>(ContinuousSByteEnum.C).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousSByteEnum>((ContinuousSByteEnum)0).Should().BeFalse();
-        FastEnum.IsDefined<ContinuousSByteEnum>((ContinuousSByteEnum)123).Should().BeFalse();
+        FastEnum.IsDefined<ContinuousSByteEnum>(ContinuousSByteEnum.A).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousSByteEnum>(ContinuousSByteEnum.B).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousSByteEnum>(ContinuousSByteEnum.C).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousSByteEnum>((ContinuousSByteEnum)0).ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousSByteEnum>((ContinuousSByteEnum)123).ShouldBeFalse();
 
         //--- Extension methods
-        ContinuousSByteEnum.A.IsDefined().Should().BeTrue();
-        ContinuousSByteEnum.B.IsDefined().Should().BeTrue();
-        ContinuousSByteEnum.C.IsDefined().Should().BeTrue();
-        ((ContinuousSByteEnum)0).IsDefined().Should().BeFalse();
-        ((ContinuousSByteEnum)123).IsDefined().Should().BeFalse();
+        ContinuousSByteEnum.A.IsDefined().ShouldBeTrue();
+        ContinuousSByteEnum.B.IsDefined().ShouldBeTrue();
+        ContinuousSByteEnum.C.IsDefined().ShouldBeTrue();
+        ((ContinuousSByteEnum)0).IsDefined().ShouldBeFalse();
+        ((ContinuousSByteEnum)123).IsDefined().ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<ContinuousSByteEnum>(nameof(ContinuousSByteEnum.A)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousSByteEnum>(nameof(ContinuousSByteEnum.B)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousSByteEnum>(nameof(ContinuousSByteEnum.C)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousSByteEnum>("0").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousSByteEnum>("123").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousSByteEnum>("value").Should().BeFalse();
+        FastEnum.IsDefined<ContinuousSByteEnum>(nameof(ContinuousSByteEnum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousSByteEnum>(nameof(ContinuousSByteEnum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousSByteEnum>(nameof(ContinuousSByteEnum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousSByteEnum>("0").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousSByteEnum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousSByteEnum>("value").ShouldBeFalse();
     }
 
 
@@ -208,18 +208,18 @@ public sealed class ContinuousSByteTests
         foreach (var x in parameters)
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousSByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ContinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ContinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousSByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousSByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ContinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<ContinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousSByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousSByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousSByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousSByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousSByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousSByteEnum>("123", ignoreCase).Should().Be((ContinuousSByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousSByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousSByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousSByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousSByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousSByteEnum>("123", ignoreCase).ShouldBe((ContinuousSByteEnum)123);
     }
 
 
@@ -236,18 +236,18 @@ public sealed class ContinuousSByteTests
         foreach (var x in parameters)
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousSByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousSByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousSByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousSByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousSByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousSByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousSByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousSByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousSByteEnum>("123", ignoreCase).Should().Be((ContinuousSByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousSByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousSByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousSByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousSByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousSByteEnum>("123", ignoreCase).ShouldBe((ContinuousSByteEnum)123);
     }
 
 
@@ -265,27 +265,27 @@ public sealed class ContinuousSByteTests
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousSByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousSByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<ContinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<ContinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<ContinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<ContinuousSByteEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousSByteEnum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousSByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousSByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousSByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousSByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousSByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousSByteEnum)123);
+        FastEnum.TryParse<ContinuousSByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousSByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousSByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousSByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousSByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousSByteEnum)123);
     }
 
 
@@ -303,30 +303,30 @@ public sealed class ContinuousSByteTests
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousSByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousSByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousSByteEnum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousSByteEnum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousSByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousSByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousSByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousSByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousSByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousSByteEnum)123);
+        FastEnum.TryParse<ContinuousSByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousSByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousSByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousSByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousSByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousSByteEnum)123);
     }
 
 
@@ -339,20 +339,20 @@ public sealed class ContinuousSByteTests
         var member = value.ToMember()!;
         var info = typeof(ContinuousSByteEnum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        ContinuousSByteEnum.A.ToName().Should().Be(nameof(ContinuousSByteEnum.A));
-        ContinuousSByteEnum.B.ToName().Should().Be(nameof(ContinuousSByteEnum.B));
-        ContinuousSByteEnum.C.ToName().Should().Be(nameof(ContinuousSByteEnum.C));
+        ContinuousSByteEnum.A.ToName().ShouldBe(nameof(ContinuousSByteEnum.A));
+        ContinuousSByteEnum.B.ToName().ShouldBe(nameof(ContinuousSByteEnum.B));
+        ContinuousSByteEnum.C.ToName().ShouldBe(nameof(ContinuousSByteEnum.C));
     }
 
 
@@ -362,14 +362,14 @@ public sealed class ContinuousSByteTests
         var @enum = ContinuousSByteEnum.A;
         const sbyte value = 1;
 
-        @enum.ToSByte().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        @enum.ToSByte().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -382,7 +382,7 @@ public sealed class ContinuousSByteTests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -394,7 +394,7 @@ public sealed class ContinuousByteTests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<ContinuousByteEnum>().Should().Be<byte>();
+        => FastEnum.GetUnderlyingType<ContinuousByteEnum>().ShouldBe(typeof(byte));
 
 
     [TestMethod]
@@ -402,7 +402,7 @@ public sealed class ContinuousByteTests
     {
         var expect = Enum.GetValues<ContinuousByteEnum>();
         var actual = FastEnum.GetValues<ContinuousByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -411,7 +411,7 @@ public sealed class ContinuousByteTests
     {
         var expect = Enum.GetNames<ContinuousByteEnum>();
         var actual = FastEnum.GetNames<ContinuousByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -423,16 +423,16 @@ public sealed class ContinuousByteTests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const ContinuousByteEnum undefined = (ContinuousByteEnum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -452,19 +452,19 @@ public sealed class ContinuousByteTests
             .ToArray();
         var actual = FastEnum.GetMembers<ContinuousByteEnum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -478,21 +478,21 @@ public sealed class ContinuousByteTests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const ContinuousByteEnum undefined = (ContinuousByteEnum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -512,8 +512,8 @@ public sealed class ContinuousByteTests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<ContinuousByteEnum>();
-        min.Should().NotBeNull();
-        min.Should().Be(ContinuousByteEnum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(ContinuousByteEnum.A);
     }
 
 
@@ -521,50 +521,50 @@ public sealed class ContinuousByteTests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<ContinuousByteEnum>();
-        max.Should().NotBeNull();
-        max.Should().Be(ContinuousByteEnum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(ContinuousByteEnum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<ContinuousByteEnum>().Should().Be(false);
+        => FastEnum.IsEmpty<ContinuousByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<ContinuousByteEnum>().Should().Be(true);
+        => FastEnum.IsContinuous<ContinuousByteEnum>().ShouldBe(true);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<ContinuousByteEnum>().Should().Be(false);
+        => FastEnum.IsFlags<ContinuousByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<ContinuousByteEnum>(ContinuousByteEnum.A).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousByteEnum>(ContinuousByteEnum.B).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousByteEnum>(ContinuousByteEnum.C).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousByteEnum>((ContinuousByteEnum)0).Should().BeFalse();
-        FastEnum.IsDefined<ContinuousByteEnum>((ContinuousByteEnum)123).Should().BeFalse();
+        FastEnum.IsDefined<ContinuousByteEnum>(ContinuousByteEnum.A).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousByteEnum>(ContinuousByteEnum.B).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousByteEnum>(ContinuousByteEnum.C).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousByteEnum>((ContinuousByteEnum)0).ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousByteEnum>((ContinuousByteEnum)123).ShouldBeFalse();
 
         //--- Extension methods
-        ContinuousByteEnum.A.IsDefined().Should().BeTrue();
-        ContinuousByteEnum.B.IsDefined().Should().BeTrue();
-        ContinuousByteEnum.C.IsDefined().Should().BeTrue();
-        ((ContinuousByteEnum)0).IsDefined().Should().BeFalse();
-        ((ContinuousByteEnum)123).IsDefined().Should().BeFalse();
+        ContinuousByteEnum.A.IsDefined().ShouldBeTrue();
+        ContinuousByteEnum.B.IsDefined().ShouldBeTrue();
+        ContinuousByteEnum.C.IsDefined().ShouldBeTrue();
+        ((ContinuousByteEnum)0).IsDefined().ShouldBeFalse();
+        ((ContinuousByteEnum)123).IsDefined().ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<ContinuousByteEnum>(nameof(ContinuousByteEnum.A)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousByteEnum>(nameof(ContinuousByteEnum.B)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousByteEnum>(nameof(ContinuousByteEnum.C)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousByteEnum>("0").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousByteEnum>("123").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousByteEnum>("value").Should().BeFalse();
+        FastEnum.IsDefined<ContinuousByteEnum>(nameof(ContinuousByteEnum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousByteEnum>(nameof(ContinuousByteEnum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousByteEnum>(nameof(ContinuousByteEnum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousByteEnum>("0").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousByteEnum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousByteEnum>("value").ShouldBeFalse();
     }
 
 
@@ -581,18 +581,18 @@ public sealed class ContinuousByteTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ContinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ContinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ContinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<ContinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousByteEnum>("123", ignoreCase).Should().Be((ContinuousByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousByteEnum>("123", ignoreCase).ShouldBe((ContinuousByteEnum)123);
     }
 
 
@@ -609,18 +609,18 @@ public sealed class ContinuousByteTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousByteEnum>("123", ignoreCase).Should().Be((ContinuousByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousByteEnum>("123", ignoreCase).ShouldBe((ContinuousByteEnum)123);
     }
 
 
@@ -638,27 +638,27 @@ public sealed class ContinuousByteTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<ContinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<ContinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<ContinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<ContinuousByteEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousByteEnum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousByteEnum)123);
+        FastEnum.TryParse<ContinuousByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousByteEnum)123);
     }
 
 
@@ -676,30 +676,30 @@ public sealed class ContinuousByteTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousByteEnum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousByteEnum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousByteEnum)123);
+        FastEnum.TryParse<ContinuousByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousByteEnum)123);
     }
 
 
@@ -712,20 +712,20 @@ public sealed class ContinuousByteTests
         var member = value.ToMember()!;
         var info = typeof(ContinuousByteEnum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        ContinuousByteEnum.A.ToName().Should().Be(nameof(ContinuousByteEnum.A));
-        ContinuousByteEnum.B.ToName().Should().Be(nameof(ContinuousByteEnum.B));
-        ContinuousByteEnum.C.ToName().Should().Be(nameof(ContinuousByteEnum.C));
+        ContinuousByteEnum.A.ToName().ShouldBe(nameof(ContinuousByteEnum.A));
+        ContinuousByteEnum.B.ToName().ShouldBe(nameof(ContinuousByteEnum.B));
+        ContinuousByteEnum.C.ToName().ShouldBe(nameof(ContinuousByteEnum.C));
     }
 
 
@@ -735,14 +735,14 @@ public sealed class ContinuousByteTests
         var @enum = ContinuousByteEnum.A;
         const byte value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        @enum.ToByte().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        @enum.ToByte().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -755,7 +755,7 @@ public sealed class ContinuousByteTests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -767,7 +767,7 @@ public sealed class ContinuousInt16Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<ContinuousInt16Enum>().Should().Be<short>();
+        => FastEnum.GetUnderlyingType<ContinuousInt16Enum>().ShouldBe(typeof(short));
 
 
     [TestMethod]
@@ -775,7 +775,7 @@ public sealed class ContinuousInt16Tests
     {
         var expect = Enum.GetValues<ContinuousInt16Enum>();
         var actual = FastEnum.GetValues<ContinuousInt16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -784,7 +784,7 @@ public sealed class ContinuousInt16Tests
     {
         var expect = Enum.GetNames<ContinuousInt16Enum>();
         var actual = FastEnum.GetNames<ContinuousInt16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -796,16 +796,16 @@ public sealed class ContinuousInt16Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const ContinuousInt16Enum undefined = (ContinuousInt16Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -825,19 +825,19 @@ public sealed class ContinuousInt16Tests
             .ToArray();
         var actual = FastEnum.GetMembers<ContinuousInt16Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -851,21 +851,21 @@ public sealed class ContinuousInt16Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const ContinuousInt16Enum undefined = (ContinuousInt16Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -885,8 +885,8 @@ public sealed class ContinuousInt16Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<ContinuousInt16Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(ContinuousInt16Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(ContinuousInt16Enum.A);
     }
 
 
@@ -894,50 +894,50 @@ public sealed class ContinuousInt16Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<ContinuousInt16Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(ContinuousInt16Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(ContinuousInt16Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<ContinuousInt16Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<ContinuousInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<ContinuousInt16Enum>().Should().Be(true);
+        => FastEnum.IsContinuous<ContinuousInt16Enum>().ShouldBe(true);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<ContinuousInt16Enum>().Should().Be(false);
+        => FastEnum.IsFlags<ContinuousInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<ContinuousInt16Enum>(ContinuousInt16Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt16Enum>(ContinuousInt16Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt16Enum>(ContinuousInt16Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt16Enum>((ContinuousInt16Enum)0).Should().BeFalse();
-        FastEnum.IsDefined<ContinuousInt16Enum>((ContinuousInt16Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<ContinuousInt16Enum>(ContinuousInt16Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt16Enum>(ContinuousInt16Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt16Enum>(ContinuousInt16Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt16Enum>((ContinuousInt16Enum)0).ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousInt16Enum>((ContinuousInt16Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        ContinuousInt16Enum.A.IsDefined().Should().BeTrue();
-        ContinuousInt16Enum.B.IsDefined().Should().BeTrue();
-        ContinuousInt16Enum.C.IsDefined().Should().BeTrue();
-        ((ContinuousInt16Enum)0).IsDefined().Should().BeFalse();
-        ((ContinuousInt16Enum)123).IsDefined().Should().BeFalse();
+        ContinuousInt16Enum.A.IsDefined().ShouldBeTrue();
+        ContinuousInt16Enum.B.IsDefined().ShouldBeTrue();
+        ContinuousInt16Enum.C.IsDefined().ShouldBeTrue();
+        ((ContinuousInt16Enum)0).IsDefined().ShouldBeFalse();
+        ((ContinuousInt16Enum)123).IsDefined().ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<ContinuousInt16Enum>(nameof(ContinuousInt16Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt16Enum>(nameof(ContinuousInt16Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt16Enum>(nameof(ContinuousInt16Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt16Enum>("0").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousInt16Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousInt16Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<ContinuousInt16Enum>(nameof(ContinuousInt16Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt16Enum>(nameof(ContinuousInt16Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt16Enum>(nameof(ContinuousInt16Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt16Enum>("0").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousInt16Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousInt16Enum>("value").ShouldBeFalse();
     }
 
 
@@ -954,18 +954,18 @@ public sealed class ContinuousInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousInt16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ContinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ContinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousInt16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ContinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<ContinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousInt16Enum>("123", ignoreCase).Should().Be((ContinuousInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousInt16Enum>("123", ignoreCase).ShouldBe((ContinuousInt16Enum)123);
     }
 
 
@@ -982,18 +982,18 @@ public sealed class ContinuousInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousInt16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousInt16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousInt16Enum>("123", ignoreCase).Should().Be((ContinuousInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousInt16Enum>("123", ignoreCase).ShouldBe((ContinuousInt16Enum)123);
     }
 
 
@@ -1011,27 +1011,27 @@ public sealed class ContinuousInt16Tests
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousInt16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<ContinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<ContinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<ContinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<ContinuousInt16Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt16Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousInt16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousInt16Enum)123);
+        FastEnum.TryParse<ContinuousInt16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousInt16Enum)123);
     }
 
 
@@ -1049,30 +1049,30 @@ public sealed class ContinuousInt16Tests
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousInt16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt16Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt16Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousInt16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousInt16Enum)123);
+        FastEnum.TryParse<ContinuousInt16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousInt16Enum)123);
     }
 
 
@@ -1085,20 +1085,20 @@ public sealed class ContinuousInt16Tests
         var member = value.ToMember()!;
         var info = typeof(ContinuousInt16Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        ContinuousInt16Enum.A.ToName().Should().Be(nameof(ContinuousInt16Enum.A));
-        ContinuousInt16Enum.B.ToName().Should().Be(nameof(ContinuousInt16Enum.B));
-        ContinuousInt16Enum.C.ToName().Should().Be(nameof(ContinuousInt16Enum.C));
+        ContinuousInt16Enum.A.ToName().ShouldBe(nameof(ContinuousInt16Enum.A));
+        ContinuousInt16Enum.B.ToName().ShouldBe(nameof(ContinuousInt16Enum.B));
+        ContinuousInt16Enum.C.ToName().ShouldBe(nameof(ContinuousInt16Enum.C));
     }
 
 
@@ -1108,14 +1108,14 @@ public sealed class ContinuousInt16Tests
         var @enum = ContinuousInt16Enum.A;
         const short value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        @enum.ToInt16().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        @enum.ToInt16().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -1128,7 +1128,7 @@ public sealed class ContinuousInt16Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1140,7 +1140,7 @@ public sealed class ContinuousUInt16Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<ContinuousUInt16Enum>().Should().Be<ushort>();
+        => FastEnum.GetUnderlyingType<ContinuousUInt16Enum>().ShouldBe(typeof(ushort));
 
 
     [TestMethod]
@@ -1148,7 +1148,7 @@ public sealed class ContinuousUInt16Tests
     {
         var expect = Enum.GetValues<ContinuousUInt16Enum>();
         var actual = FastEnum.GetValues<ContinuousUInt16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1157,7 +1157,7 @@ public sealed class ContinuousUInt16Tests
     {
         var expect = Enum.GetNames<ContinuousUInt16Enum>();
         var actual = FastEnum.GetNames<ContinuousUInt16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1169,16 +1169,16 @@ public sealed class ContinuousUInt16Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const ContinuousUInt16Enum undefined = (ContinuousUInt16Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1198,19 +1198,19 @@ public sealed class ContinuousUInt16Tests
             .ToArray();
         var actual = FastEnum.GetMembers<ContinuousUInt16Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -1224,21 +1224,21 @@ public sealed class ContinuousUInt16Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const ContinuousUInt16Enum undefined = (ContinuousUInt16Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -1258,8 +1258,8 @@ public sealed class ContinuousUInt16Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<ContinuousUInt16Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(ContinuousUInt16Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(ContinuousUInt16Enum.A);
     }
 
 
@@ -1267,50 +1267,50 @@ public sealed class ContinuousUInt16Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<ContinuousUInt16Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(ContinuousUInt16Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(ContinuousUInt16Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<ContinuousUInt16Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<ContinuousUInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<ContinuousUInt16Enum>().Should().Be(true);
+        => FastEnum.IsContinuous<ContinuousUInt16Enum>().ShouldBe(true);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<ContinuousUInt16Enum>().Should().Be(false);
+        => FastEnum.IsFlags<ContinuousUInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<ContinuousUInt16Enum>(ContinuousUInt16Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt16Enum>(ContinuousUInt16Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt16Enum>(ContinuousUInt16Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt16Enum>((ContinuousUInt16Enum)0).Should().BeFalse();
-        FastEnum.IsDefined<ContinuousUInt16Enum>((ContinuousUInt16Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<ContinuousUInt16Enum>(ContinuousUInt16Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt16Enum>(ContinuousUInt16Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt16Enum>(ContinuousUInt16Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt16Enum>((ContinuousUInt16Enum)0).ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousUInt16Enum>((ContinuousUInt16Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        ContinuousUInt16Enum.A.IsDefined().Should().BeTrue();
-        ContinuousUInt16Enum.B.IsDefined().Should().BeTrue();
-        ContinuousUInt16Enum.C.IsDefined().Should().BeTrue();
-        ((ContinuousUInt16Enum)0).IsDefined().Should().BeFalse();
-        ((ContinuousUInt16Enum)123).IsDefined().Should().BeFalse();
+        ContinuousUInt16Enum.A.IsDefined().ShouldBeTrue();
+        ContinuousUInt16Enum.B.IsDefined().ShouldBeTrue();
+        ContinuousUInt16Enum.C.IsDefined().ShouldBeTrue();
+        ((ContinuousUInt16Enum)0).IsDefined().ShouldBeFalse();
+        ((ContinuousUInt16Enum)123).IsDefined().ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<ContinuousUInt16Enum>(nameof(ContinuousUInt16Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt16Enum>(nameof(ContinuousUInt16Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt16Enum>(nameof(ContinuousUInt16Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt16Enum>("0").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousUInt16Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousUInt16Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<ContinuousUInt16Enum>(nameof(ContinuousUInt16Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt16Enum>(nameof(ContinuousUInt16Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt16Enum>(nameof(ContinuousUInt16Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt16Enum>("0").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousUInt16Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousUInt16Enum>("value").ShouldBeFalse();
     }
 
 
@@ -1327,18 +1327,18 @@ public sealed class ContinuousUInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousUInt16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ContinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ContinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousUInt16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ContinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<ContinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousUInt16Enum>("123", ignoreCase).Should().Be((ContinuousUInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousUInt16Enum>("123", ignoreCase).ShouldBe((ContinuousUInt16Enum)123);
     }
 
 
@@ -1355,18 +1355,18 @@ public sealed class ContinuousUInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousUInt16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousUInt16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousUInt16Enum>("123", ignoreCase).Should().Be((ContinuousUInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousUInt16Enum>("123", ignoreCase).ShouldBe((ContinuousUInt16Enum)123);
     }
 
 
@@ -1384,27 +1384,27 @@ public sealed class ContinuousUInt16Tests
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<ContinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<ContinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<ContinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt16Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousUInt16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousUInt16Enum)123);
+        FastEnum.TryParse<ContinuousUInt16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousUInt16Enum)123);
     }
 
 
@@ -1422,30 +1422,30 @@ public sealed class ContinuousUInt16Tests
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt16Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousUInt16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousUInt16Enum)123);
+        FastEnum.TryParse<ContinuousUInt16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousUInt16Enum)123);
     }
 
 
@@ -1458,20 +1458,20 @@ public sealed class ContinuousUInt16Tests
         var member = value.ToMember()!;
         var info = typeof(ContinuousUInt16Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        ContinuousUInt16Enum.A.ToName().Should().Be(nameof(ContinuousUInt16Enum.A));
-        ContinuousUInt16Enum.B.ToName().Should().Be(nameof(ContinuousUInt16Enum.B));
-        ContinuousUInt16Enum.C.ToName().Should().Be(nameof(ContinuousUInt16Enum.C));
+        ContinuousUInt16Enum.A.ToName().ShouldBe(nameof(ContinuousUInt16Enum.A));
+        ContinuousUInt16Enum.B.ToName().ShouldBe(nameof(ContinuousUInt16Enum.B));
+        ContinuousUInt16Enum.C.ToName().ShouldBe(nameof(ContinuousUInt16Enum.C));
     }
 
 
@@ -1481,14 +1481,14 @@ public sealed class ContinuousUInt16Tests
         var @enum = ContinuousUInt16Enum.A;
         const ushort value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        @enum.ToUInt16().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        @enum.ToUInt16().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -1501,7 +1501,7 @@ public sealed class ContinuousUInt16Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1513,7 +1513,7 @@ public sealed class ContinuousInt32Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<ContinuousInt32Enum>().Should().Be<int>();
+        => FastEnum.GetUnderlyingType<ContinuousInt32Enum>().ShouldBe(typeof(int));
 
 
     [TestMethod]
@@ -1521,7 +1521,7 @@ public sealed class ContinuousInt32Tests
     {
         var expect = Enum.GetValues<ContinuousInt32Enum>();
         var actual = FastEnum.GetValues<ContinuousInt32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1530,7 +1530,7 @@ public sealed class ContinuousInt32Tests
     {
         var expect = Enum.GetNames<ContinuousInt32Enum>();
         var actual = FastEnum.GetNames<ContinuousInt32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1542,16 +1542,16 @@ public sealed class ContinuousInt32Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const ContinuousInt32Enum undefined = (ContinuousInt32Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1571,19 +1571,19 @@ public sealed class ContinuousInt32Tests
             .ToArray();
         var actual = FastEnum.GetMembers<ContinuousInt32Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -1597,21 +1597,21 @@ public sealed class ContinuousInt32Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const ContinuousInt32Enum undefined = (ContinuousInt32Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -1631,8 +1631,8 @@ public sealed class ContinuousInt32Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<ContinuousInt32Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(ContinuousInt32Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(ContinuousInt32Enum.A);
     }
 
 
@@ -1640,50 +1640,50 @@ public sealed class ContinuousInt32Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<ContinuousInt32Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(ContinuousInt32Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(ContinuousInt32Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<ContinuousInt32Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<ContinuousInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<ContinuousInt32Enum>().Should().Be(true);
+        => FastEnum.IsContinuous<ContinuousInt32Enum>().ShouldBe(true);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<ContinuousInt32Enum>().Should().Be(false);
+        => FastEnum.IsFlags<ContinuousInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<ContinuousInt32Enum>(ContinuousInt32Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt32Enum>(ContinuousInt32Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt32Enum>(ContinuousInt32Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt32Enum>((ContinuousInt32Enum)0).Should().BeFalse();
-        FastEnum.IsDefined<ContinuousInt32Enum>((ContinuousInt32Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<ContinuousInt32Enum>(ContinuousInt32Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt32Enum>(ContinuousInt32Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt32Enum>(ContinuousInt32Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt32Enum>((ContinuousInt32Enum)0).ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousInt32Enum>((ContinuousInt32Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        ContinuousInt32Enum.A.IsDefined().Should().BeTrue();
-        ContinuousInt32Enum.B.IsDefined().Should().BeTrue();
-        ContinuousInt32Enum.C.IsDefined().Should().BeTrue();
-        ((ContinuousInt32Enum)0).IsDefined().Should().BeFalse();
-        ((ContinuousInt32Enum)123).IsDefined().Should().BeFalse();
+        ContinuousInt32Enum.A.IsDefined().ShouldBeTrue();
+        ContinuousInt32Enum.B.IsDefined().ShouldBeTrue();
+        ContinuousInt32Enum.C.IsDefined().ShouldBeTrue();
+        ((ContinuousInt32Enum)0).IsDefined().ShouldBeFalse();
+        ((ContinuousInt32Enum)123).IsDefined().ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<ContinuousInt32Enum>(nameof(ContinuousInt32Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt32Enum>(nameof(ContinuousInt32Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt32Enum>(nameof(ContinuousInt32Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt32Enum>("0").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousInt32Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousInt32Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<ContinuousInt32Enum>(nameof(ContinuousInt32Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt32Enum>(nameof(ContinuousInt32Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt32Enum>(nameof(ContinuousInt32Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt32Enum>("0").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousInt32Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousInt32Enum>("value").ShouldBeFalse();
     }
 
 
@@ -1700,18 +1700,18 @@ public sealed class ContinuousInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousInt32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ContinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ContinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousInt32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ContinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<ContinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousInt32Enum>("123", ignoreCase).Should().Be((ContinuousInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousInt32Enum>("123", ignoreCase).ShouldBe((ContinuousInt32Enum)123);
     }
 
 
@@ -1728,18 +1728,18 @@ public sealed class ContinuousInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousInt32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousInt32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousInt32Enum>("123", ignoreCase).Should().Be((ContinuousInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousInt32Enum>("123", ignoreCase).ShouldBe((ContinuousInt32Enum)123);
     }
 
 
@@ -1757,27 +1757,27 @@ public sealed class ContinuousInt32Tests
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousInt32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<ContinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<ContinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<ContinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<ContinuousInt32Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt32Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousInt32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousInt32Enum)123);
+        FastEnum.TryParse<ContinuousInt32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousInt32Enum)123);
     }
 
 
@@ -1795,30 +1795,30 @@ public sealed class ContinuousInt32Tests
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousInt32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt32Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt32Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousInt32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousInt32Enum)123);
+        FastEnum.TryParse<ContinuousInt32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousInt32Enum)123);
     }
 
 
@@ -1831,20 +1831,20 @@ public sealed class ContinuousInt32Tests
         var member = value.ToMember()!;
         var info = typeof(ContinuousInt32Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        ContinuousInt32Enum.A.ToName().Should().Be(nameof(ContinuousInt32Enum.A));
-        ContinuousInt32Enum.B.ToName().Should().Be(nameof(ContinuousInt32Enum.B));
-        ContinuousInt32Enum.C.ToName().Should().Be(nameof(ContinuousInt32Enum.C));
+        ContinuousInt32Enum.A.ToName().ShouldBe(nameof(ContinuousInt32Enum.A));
+        ContinuousInt32Enum.B.ToName().ShouldBe(nameof(ContinuousInt32Enum.B));
+        ContinuousInt32Enum.C.ToName().ShouldBe(nameof(ContinuousInt32Enum.C));
     }
 
 
@@ -1854,14 +1854,14 @@ public sealed class ContinuousInt32Tests
         var @enum = ContinuousInt32Enum.A;
         const int value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        @enum.ToInt32().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        @enum.ToInt32().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -1874,7 +1874,7 @@ public sealed class ContinuousInt32Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1886,7 +1886,7 @@ public sealed class ContinuousUInt32Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<ContinuousUInt32Enum>().Should().Be<uint>();
+        => FastEnum.GetUnderlyingType<ContinuousUInt32Enum>().ShouldBe(typeof(uint));
 
 
     [TestMethod]
@@ -1894,7 +1894,7 @@ public sealed class ContinuousUInt32Tests
     {
         var expect = Enum.GetValues<ContinuousUInt32Enum>();
         var actual = FastEnum.GetValues<ContinuousUInt32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1903,7 +1903,7 @@ public sealed class ContinuousUInt32Tests
     {
         var expect = Enum.GetNames<ContinuousUInt32Enum>();
         var actual = FastEnum.GetNames<ContinuousUInt32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1915,16 +1915,16 @@ public sealed class ContinuousUInt32Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const ContinuousUInt32Enum undefined = (ContinuousUInt32Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1944,19 +1944,19 @@ public sealed class ContinuousUInt32Tests
             .ToArray();
         var actual = FastEnum.GetMembers<ContinuousUInt32Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -1970,21 +1970,21 @@ public sealed class ContinuousUInt32Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const ContinuousUInt32Enum undefined = (ContinuousUInt32Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -2004,8 +2004,8 @@ public sealed class ContinuousUInt32Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<ContinuousUInt32Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(ContinuousUInt32Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(ContinuousUInt32Enum.A);
     }
 
 
@@ -2013,50 +2013,50 @@ public sealed class ContinuousUInt32Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<ContinuousUInt32Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(ContinuousUInt32Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(ContinuousUInt32Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<ContinuousUInt32Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<ContinuousUInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<ContinuousUInt32Enum>().Should().Be(true);
+        => FastEnum.IsContinuous<ContinuousUInt32Enum>().ShouldBe(true);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<ContinuousUInt32Enum>().Should().Be(false);
+        => FastEnum.IsFlags<ContinuousUInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<ContinuousUInt32Enum>(ContinuousUInt32Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt32Enum>(ContinuousUInt32Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt32Enum>(ContinuousUInt32Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt32Enum>((ContinuousUInt32Enum)0).Should().BeFalse();
-        FastEnum.IsDefined<ContinuousUInt32Enum>((ContinuousUInt32Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<ContinuousUInt32Enum>(ContinuousUInt32Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt32Enum>(ContinuousUInt32Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt32Enum>(ContinuousUInt32Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt32Enum>((ContinuousUInt32Enum)0).ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousUInt32Enum>((ContinuousUInt32Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        ContinuousUInt32Enum.A.IsDefined().Should().BeTrue();
-        ContinuousUInt32Enum.B.IsDefined().Should().BeTrue();
-        ContinuousUInt32Enum.C.IsDefined().Should().BeTrue();
-        ((ContinuousUInt32Enum)0).IsDefined().Should().BeFalse();
-        ((ContinuousUInt32Enum)123).IsDefined().Should().BeFalse();
+        ContinuousUInt32Enum.A.IsDefined().ShouldBeTrue();
+        ContinuousUInt32Enum.B.IsDefined().ShouldBeTrue();
+        ContinuousUInt32Enum.C.IsDefined().ShouldBeTrue();
+        ((ContinuousUInt32Enum)0).IsDefined().ShouldBeFalse();
+        ((ContinuousUInt32Enum)123).IsDefined().ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<ContinuousUInt32Enum>(nameof(ContinuousUInt32Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt32Enum>(nameof(ContinuousUInt32Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt32Enum>(nameof(ContinuousUInt32Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt32Enum>("0").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousUInt32Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousUInt32Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<ContinuousUInt32Enum>(nameof(ContinuousUInt32Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt32Enum>(nameof(ContinuousUInt32Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt32Enum>(nameof(ContinuousUInt32Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt32Enum>("0").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousUInt32Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousUInt32Enum>("value").ShouldBeFalse();
     }
 
 
@@ -2073,18 +2073,18 @@ public sealed class ContinuousUInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousUInt32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ContinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ContinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousUInt32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ContinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<ContinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousUInt32Enum>("123", ignoreCase).Should().Be((ContinuousUInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousUInt32Enum>("123", ignoreCase).ShouldBe((ContinuousUInt32Enum)123);
     }
 
 
@@ -2101,18 +2101,18 @@ public sealed class ContinuousUInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousUInt32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousUInt32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousUInt32Enum>("123", ignoreCase).Should().Be((ContinuousUInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousUInt32Enum>("123", ignoreCase).ShouldBe((ContinuousUInt32Enum)123);
     }
 
 
@@ -2130,27 +2130,27 @@ public sealed class ContinuousUInt32Tests
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<ContinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<ContinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<ContinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt32Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousUInt32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousUInt32Enum)123);
+        FastEnum.TryParse<ContinuousUInt32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousUInt32Enum)123);
     }
 
 
@@ -2168,30 +2168,30 @@ public sealed class ContinuousUInt32Tests
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt32Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousUInt32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousUInt32Enum)123);
+        FastEnum.TryParse<ContinuousUInt32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousUInt32Enum)123);
     }
 
 
@@ -2204,20 +2204,20 @@ public sealed class ContinuousUInt32Tests
         var member = value.ToMember()!;
         var info = typeof(ContinuousUInt32Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        ContinuousUInt32Enum.A.ToName().Should().Be(nameof(ContinuousUInt32Enum.A));
-        ContinuousUInt32Enum.B.ToName().Should().Be(nameof(ContinuousUInt32Enum.B));
-        ContinuousUInt32Enum.C.ToName().Should().Be(nameof(ContinuousUInt32Enum.C));
+        ContinuousUInt32Enum.A.ToName().ShouldBe(nameof(ContinuousUInt32Enum.A));
+        ContinuousUInt32Enum.B.ToName().ShouldBe(nameof(ContinuousUInt32Enum.B));
+        ContinuousUInt32Enum.C.ToName().ShouldBe(nameof(ContinuousUInt32Enum.C));
     }
 
 
@@ -2227,14 +2227,14 @@ public sealed class ContinuousUInt32Tests
         var @enum = ContinuousUInt32Enum.A;
         const uint value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        @enum.ToUInt32().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        @enum.ToUInt32().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -2247,7 +2247,7 @@ public sealed class ContinuousUInt32Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -2259,7 +2259,7 @@ public sealed class ContinuousInt64Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<ContinuousInt64Enum>().Should().Be<long>();
+        => FastEnum.GetUnderlyingType<ContinuousInt64Enum>().ShouldBe(typeof(long));
 
 
     [TestMethod]
@@ -2267,7 +2267,7 @@ public sealed class ContinuousInt64Tests
     {
         var expect = Enum.GetValues<ContinuousInt64Enum>();
         var actual = FastEnum.GetValues<ContinuousInt64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2276,7 +2276,7 @@ public sealed class ContinuousInt64Tests
     {
         var expect = Enum.GetNames<ContinuousInt64Enum>();
         var actual = FastEnum.GetNames<ContinuousInt64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2288,16 +2288,16 @@ public sealed class ContinuousInt64Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const ContinuousInt64Enum undefined = (ContinuousInt64Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -2317,19 +2317,19 @@ public sealed class ContinuousInt64Tests
             .ToArray();
         var actual = FastEnum.GetMembers<ContinuousInt64Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -2343,21 +2343,21 @@ public sealed class ContinuousInt64Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const ContinuousInt64Enum undefined = (ContinuousInt64Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -2377,8 +2377,8 @@ public sealed class ContinuousInt64Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<ContinuousInt64Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(ContinuousInt64Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(ContinuousInt64Enum.A);
     }
 
 
@@ -2386,50 +2386,50 @@ public sealed class ContinuousInt64Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<ContinuousInt64Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(ContinuousInt64Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(ContinuousInt64Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<ContinuousInt64Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<ContinuousInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<ContinuousInt64Enum>().Should().Be(true);
+        => FastEnum.IsContinuous<ContinuousInt64Enum>().ShouldBe(true);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<ContinuousInt64Enum>().Should().Be(false);
+        => FastEnum.IsFlags<ContinuousInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<ContinuousInt64Enum>(ContinuousInt64Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt64Enum>(ContinuousInt64Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt64Enum>(ContinuousInt64Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt64Enum>((ContinuousInt64Enum)0).Should().BeFalse();
-        FastEnum.IsDefined<ContinuousInt64Enum>((ContinuousInt64Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<ContinuousInt64Enum>(ContinuousInt64Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt64Enum>(ContinuousInt64Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt64Enum>(ContinuousInt64Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt64Enum>((ContinuousInt64Enum)0).ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousInt64Enum>((ContinuousInt64Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        ContinuousInt64Enum.A.IsDefined().Should().BeTrue();
-        ContinuousInt64Enum.B.IsDefined().Should().BeTrue();
-        ContinuousInt64Enum.C.IsDefined().Should().BeTrue();
-        ((ContinuousInt64Enum)0).IsDefined().Should().BeFalse();
-        ((ContinuousInt64Enum)123).IsDefined().Should().BeFalse();
+        ContinuousInt64Enum.A.IsDefined().ShouldBeTrue();
+        ContinuousInt64Enum.B.IsDefined().ShouldBeTrue();
+        ContinuousInt64Enum.C.IsDefined().ShouldBeTrue();
+        ((ContinuousInt64Enum)0).IsDefined().ShouldBeFalse();
+        ((ContinuousInt64Enum)123).IsDefined().ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<ContinuousInt64Enum>(nameof(ContinuousInt64Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt64Enum>(nameof(ContinuousInt64Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt64Enum>(nameof(ContinuousInt64Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousInt64Enum>("0").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousInt64Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousInt64Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<ContinuousInt64Enum>(nameof(ContinuousInt64Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt64Enum>(nameof(ContinuousInt64Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt64Enum>(nameof(ContinuousInt64Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousInt64Enum>("0").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousInt64Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousInt64Enum>("value").ShouldBeFalse();
     }
 
 
@@ -2446,18 +2446,18 @@ public sealed class ContinuousInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousInt64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ContinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ContinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousInt64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ContinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<ContinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousInt64Enum>("123", ignoreCase).Should().Be((ContinuousInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousInt64Enum>("123", ignoreCase).ShouldBe((ContinuousInt64Enum)123);
     }
 
 
@@ -2474,18 +2474,18 @@ public sealed class ContinuousInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousInt64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousInt64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousInt64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousInt64Enum>("123", ignoreCase).Should().Be((ContinuousInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousInt64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousInt64Enum>("123", ignoreCase).ShouldBe((ContinuousInt64Enum)123);
     }
 
 
@@ -2503,27 +2503,27 @@ public sealed class ContinuousInt64Tests
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousInt64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<ContinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<ContinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<ContinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<ContinuousInt64Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt64Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousInt64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousInt64Enum)123);
+        FastEnum.TryParse<ContinuousInt64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousInt64Enum)123);
     }
 
 
@@ -2541,30 +2541,30 @@ public sealed class ContinuousInt64Tests
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousInt64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt64Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt64Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousInt64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousInt64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousInt64Enum)123);
+        FastEnum.TryParse<ContinuousInt64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousInt64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousInt64Enum)123);
     }
 
 
@@ -2577,20 +2577,20 @@ public sealed class ContinuousInt64Tests
         var member = value.ToMember()!;
         var info = typeof(ContinuousInt64Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        ContinuousInt64Enum.A.ToName().Should().Be(nameof(ContinuousInt64Enum.A));
-        ContinuousInt64Enum.B.ToName().Should().Be(nameof(ContinuousInt64Enum.B));
-        ContinuousInt64Enum.C.ToName().Should().Be(nameof(ContinuousInt64Enum.C));
+        ContinuousInt64Enum.A.ToName().ShouldBe(nameof(ContinuousInt64Enum.A));
+        ContinuousInt64Enum.B.ToName().ShouldBe(nameof(ContinuousInt64Enum.B));
+        ContinuousInt64Enum.C.ToName().ShouldBe(nameof(ContinuousInt64Enum.C));
     }
 
 
@@ -2600,14 +2600,14 @@ public sealed class ContinuousInt64Tests
         var @enum = ContinuousInt64Enum.A;
         const long value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        @enum.ToInt64().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        @enum.ToInt64().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -2620,7 +2620,7 @@ public sealed class ContinuousInt64Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -2632,7 +2632,7 @@ public sealed class ContinuousUInt64Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<ContinuousUInt64Enum>().Should().Be<ulong>();
+        => FastEnum.GetUnderlyingType<ContinuousUInt64Enum>().ShouldBe(typeof(ulong));
 
 
     [TestMethod]
@@ -2640,7 +2640,7 @@ public sealed class ContinuousUInt64Tests
     {
         var expect = Enum.GetValues<ContinuousUInt64Enum>();
         var actual = FastEnum.GetValues<ContinuousUInt64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2649,7 +2649,7 @@ public sealed class ContinuousUInt64Tests
     {
         var expect = Enum.GetNames<ContinuousUInt64Enum>();
         var actual = FastEnum.GetNames<ContinuousUInt64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2661,16 +2661,16 @@ public sealed class ContinuousUInt64Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const ContinuousUInt64Enum undefined = (ContinuousUInt64Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -2690,19 +2690,19 @@ public sealed class ContinuousUInt64Tests
             .ToArray();
         var actual = FastEnum.GetMembers<ContinuousUInt64Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -2716,21 +2716,21 @@ public sealed class ContinuousUInt64Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const ContinuousUInt64Enum undefined = (ContinuousUInt64Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -2750,8 +2750,8 @@ public sealed class ContinuousUInt64Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<ContinuousUInt64Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(ContinuousUInt64Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(ContinuousUInt64Enum.A);
     }
 
 
@@ -2759,50 +2759,50 @@ public sealed class ContinuousUInt64Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<ContinuousUInt64Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(ContinuousUInt64Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(ContinuousUInt64Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<ContinuousUInt64Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<ContinuousUInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<ContinuousUInt64Enum>().Should().Be(true);
+        => FastEnum.IsContinuous<ContinuousUInt64Enum>().ShouldBe(true);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<ContinuousUInt64Enum>().Should().Be(false);
+        => FastEnum.IsFlags<ContinuousUInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<ContinuousUInt64Enum>(ContinuousUInt64Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt64Enum>(ContinuousUInt64Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt64Enum>(ContinuousUInt64Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt64Enum>((ContinuousUInt64Enum)0).Should().BeFalse();
-        FastEnum.IsDefined<ContinuousUInt64Enum>((ContinuousUInt64Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<ContinuousUInt64Enum>(ContinuousUInt64Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt64Enum>(ContinuousUInt64Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt64Enum>(ContinuousUInt64Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt64Enum>((ContinuousUInt64Enum)0).ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousUInt64Enum>((ContinuousUInt64Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        ContinuousUInt64Enum.A.IsDefined().Should().BeTrue();
-        ContinuousUInt64Enum.B.IsDefined().Should().BeTrue();
-        ContinuousUInt64Enum.C.IsDefined().Should().BeTrue();
-        ((ContinuousUInt64Enum)0).IsDefined().Should().BeFalse();
-        ((ContinuousUInt64Enum)123).IsDefined().Should().BeFalse();
+        ContinuousUInt64Enum.A.IsDefined().ShouldBeTrue();
+        ContinuousUInt64Enum.B.IsDefined().ShouldBeTrue();
+        ContinuousUInt64Enum.C.IsDefined().ShouldBeTrue();
+        ((ContinuousUInt64Enum)0).IsDefined().ShouldBeFalse();
+        ((ContinuousUInt64Enum)123).IsDefined().ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<ContinuousUInt64Enum>(nameof(ContinuousUInt64Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt64Enum>(nameof(ContinuousUInt64Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt64Enum>(nameof(ContinuousUInt64Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<ContinuousUInt64Enum>("0").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousUInt64Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<ContinuousUInt64Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<ContinuousUInt64Enum>(nameof(ContinuousUInt64Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt64Enum>(nameof(ContinuousUInt64Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt64Enum>(nameof(ContinuousUInt64Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<ContinuousUInt64Enum>("0").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousUInt64Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<ContinuousUInt64Enum>("value").ShouldBeFalse();
     }
 
 
@@ -2819,18 +2819,18 @@ public sealed class ContinuousUInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousUInt64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<ContinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<ContinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousUInt64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<ContinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<ContinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousUInt64Enum>("123", ignoreCase).Should().Be((ContinuousUInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousUInt64Enum>("123", ignoreCase).ShouldBe((ContinuousUInt64Enum)123);
     }
 
 
@@ -2847,18 +2847,18 @@ public sealed class ContinuousUInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<ContinuousUInt64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<ContinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<ContinuousUInt64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<ContinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<ContinuousUInt64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<ContinuousUInt64Enum>("123", ignoreCase).Should().Be((ContinuousUInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<ContinuousUInt64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<ContinuousUInt64Enum>("123", ignoreCase).ShouldBe((ContinuousUInt64Enum)123);
     }
 
 
@@ -2876,27 +2876,27 @@ public sealed class ContinuousUInt64Tests
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<ContinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<ContinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<ContinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt64Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousUInt64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousUInt64Enum)123);
+        FastEnum.TryParse<ContinuousUInt64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousUInt64Enum)123);
     }
 
 
@@ -2914,30 +2914,30 @@ public sealed class ContinuousUInt64Tests
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt64Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<ContinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<ContinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<ContinuousUInt64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<ContinuousUInt64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((ContinuousUInt64Enum)123);
+        FastEnum.TryParse<ContinuousUInt64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<ContinuousUInt64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((ContinuousUInt64Enum)123);
     }
 
 
@@ -2950,20 +2950,20 @@ public sealed class ContinuousUInt64Tests
         var member = value.ToMember()!;
         var info = typeof(ContinuousUInt64Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        ContinuousUInt64Enum.A.ToName().Should().Be(nameof(ContinuousUInt64Enum.A));
-        ContinuousUInt64Enum.B.ToName().Should().Be(nameof(ContinuousUInt64Enum.B));
-        ContinuousUInt64Enum.C.ToName().Should().Be(nameof(ContinuousUInt64Enum.C));
+        ContinuousUInt64Enum.A.ToName().ShouldBe(nameof(ContinuousUInt64Enum.A));
+        ContinuousUInt64Enum.B.ToName().ShouldBe(nameof(ContinuousUInt64Enum.B));
+        ContinuousUInt64Enum.C.ToName().ShouldBe(nameof(ContinuousUInt64Enum.C));
     }
 
 
@@ -2973,14 +2973,14 @@ public sealed class ContinuousUInt64Tests
         var @enum = ContinuousUInt64Enum.A;
         const ulong value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        @enum.ToUInt64().Should().Be(value);
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        @enum.ToUInt64().ShouldBe(value);
     }
 
 
@@ -2993,7 +2993,7 @@ public sealed class ContinuousUInt64Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/ContinuousTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/ContinuousTests.tt
@@ -27,8 +27,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
 
@@ -40,7 +40,7 @@ public sealed class Continuous<#= x.AliasType #>Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<<#= x.EnumType #>>().Should().Be<<#= x.UnderlyingType #>>();
+        => FastEnum.GetUnderlyingType<<#= x.EnumType #>>().ShouldBe(typeof(<#= x.UnderlyingType #>));
 
 
     [TestMethod]
@@ -48,7 +48,7 @@ public sealed class Continuous<#= x.AliasType #>Tests
     {
         var expect = Enum.GetValues<<#= x.EnumType #>>();
         var actual = FastEnum.GetValues<<#= x.EnumType #>>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -57,7 +57,7 @@ public sealed class Continuous<#= x.AliasType #>Tests
     {
         var expect = Enum.GetNames<<#= x.EnumType #>>();
         var actual = FastEnum.GetNames<<#= x.EnumType #>>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -69,16 +69,16 @@ public sealed class Continuous<#= x.AliasType #>Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const <#= x.EnumType #> undefined = (<#= x.EnumType #>)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -98,19 +98,19 @@ public sealed class Continuous<#= x.AliasType #>Tests
             .ToArray();
         var actual = FastEnum.GetMembers<<#= x.EnumType #>>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -124,21 +124,21 @@ public sealed class Continuous<#= x.AliasType #>Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const <#= x.EnumType #> undefined = (<#= x.EnumType #>)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -158,8 +158,8 @@ public sealed class Continuous<#= x.AliasType #>Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<<#= x.EnumType #>>();
-        min.Should().NotBeNull();
-        min.Should().Be(<#= x.EnumType #>.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(<#= x.EnumType #>.A);
     }
 
 
@@ -167,50 +167,50 @@ public sealed class Continuous<#= x.AliasType #>Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<<#= x.EnumType #>>();
-        max.Should().NotBeNull();
-        max.Should().Be(<#= x.EnumType #>.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(<#= x.EnumType #>.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<<#= x.EnumType #>>().Should().Be(false);
+        => FastEnum.IsEmpty<<#= x.EnumType #>>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<<#= x.EnumType #>>().Should().Be(true);
+        => FastEnum.IsContinuous<<#= x.EnumType #>>().ShouldBe(true);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<<#= x.EnumType #>>().Should().Be(false);
+        => FastEnum.IsFlags<<#= x.EnumType #>>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.A).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.B).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.C).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>((<#= x.EnumType #>)0).Should().BeFalse();
-        FastEnum.IsDefined<<#= x.EnumType #>>((<#= x.EnumType #>)123).Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.A).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.B).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.C).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>((<#= x.EnumType #>)0).ShouldBeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>((<#= x.EnumType #>)123).ShouldBeFalse();
 
         //--- Extension methods
-        <#= x.EnumType #>.A.IsDefined().Should().BeTrue();
-        <#= x.EnumType #>.B.IsDefined().Should().BeTrue();
-        <#= x.EnumType #>.C.IsDefined().Should().BeTrue();
-        ((<#= x.EnumType #>)0).IsDefined().Should().BeFalse();
-        ((<#= x.EnumType #>)123).IsDefined().Should().BeFalse();
+        <#= x.EnumType #>.A.IsDefined().ShouldBeTrue();
+        <#= x.EnumType #>.B.IsDefined().ShouldBeTrue();
+        <#= x.EnumType #>.C.IsDefined().ShouldBeTrue();
+        ((<#= x.EnumType #>)0).IsDefined().ShouldBeFalse();
+        ((<#= x.EnumType #>)123).IsDefined().ShouldBeFalse();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.A)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.B)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.C)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>("0").Should().BeFalse();
-        FastEnum.IsDefined<<#= x.EnumType #>>("123").Should().BeFalse();
-        FastEnum.IsDefined<<#= x.EnumType #>>("value").Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.A)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.B)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.C)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>("0").ShouldBeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>("123").ShouldBeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>("value").ShouldBeFalse();
     }
 
 
@@ -227,18 +227,18 @@ public sealed class Continuous<#= x.AliasType #>Tests
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -255,18 +255,18 @@ public sealed class Continuous<#= x.AliasType #>Tests
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -284,27 +284,27 @@ public sealed class Continuous<#= x.AliasType #>Tests
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -322,30 +322,30 @@ public sealed class Continuous<#= x.AliasType #>Tests
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -358,20 +358,20 @@ public sealed class Continuous<#= x.AliasType #>Tests
         var member = value.ToMember()!;
         var info = typeof(<#= x.EnumType #>).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        <#= x.EnumType #>.A.ToName().Should().Be(nameof(<#= x.EnumType #>.A));
-        <#= x.EnumType #>.B.ToName().Should().Be(nameof(<#= x.EnumType #>.B));
-        <#= x.EnumType #>.C.ToName().Should().Be(nameof(<#= x.EnumType #>.C));
+        <#= x.EnumType #>.A.ToName().ShouldBe(nameof(<#= x.EnumType #>.A));
+        <#= x.EnumType #>.B.ToName().ShouldBe(nameof(<#= x.EnumType #>.B));
+        <#= x.EnumType #>.C.ToName().ShouldBe(nameof(<#= x.EnumType #>.C));
     }
 
 
@@ -383,9 +383,9 @@ public sealed class Continuous<#= x.AliasType #>Tests
 
 <# foreach (var y in parameters) { #>
 <# if (x.EnumType == y.EnumType) { #>
-        @enum.To<#= y.AliasType #>().Should().Be(value);
+        @enum.To<#= y.AliasType #>().ShouldBe(value);
 <# } else { #>
-        FluentActions.Invoking(() => @enum.To<#= y.AliasType #>()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.To<#= y.AliasType #>());
 <# } #>
 <# } #>
     }
@@ -400,7 +400,7 @@ public sealed class Continuous<#= x.AliasType #>Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/DiscontinuousTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/DiscontinuousTests.cs
@@ -9,8 +9,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
 
@@ -21,7 +21,7 @@ public sealed class DiscontinuousSByteTests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<DiscontinuousSByteEnum>().Should().Be<sbyte>();
+        => FastEnum.GetUnderlyingType<DiscontinuousSByteEnum>().ShouldBe(typeof(sbyte));
 
 
     [TestMethod]
@@ -29,7 +29,7 @@ public sealed class DiscontinuousSByteTests
     {
         var expect = Enum.GetValues<DiscontinuousSByteEnum>();
         var actual = FastEnum.GetValues<DiscontinuousSByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -38,7 +38,7 @@ public sealed class DiscontinuousSByteTests
     {
         var expect = Enum.GetNames<DiscontinuousSByteEnum>();
         var actual = FastEnum.GetNames<DiscontinuousSByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -50,16 +50,16 @@ public sealed class DiscontinuousSByteTests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const DiscontinuousSByteEnum undefined = (DiscontinuousSByteEnum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -79,19 +79,19 @@ public sealed class DiscontinuousSByteTests
             .ToArray();
         var actual = FastEnum.GetMembers<DiscontinuousSByteEnum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -105,21 +105,21 @@ public sealed class DiscontinuousSByteTests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const DiscontinuousSByteEnum undefined = (DiscontinuousSByteEnum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -139,8 +139,8 @@ public sealed class DiscontinuousSByteTests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<DiscontinuousSByteEnum>();
-        min.Should().NotBeNull();
-        min.Should().Be(DiscontinuousSByteEnum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(DiscontinuousSByteEnum.A);
     }
 
 
@@ -148,46 +148,46 @@ public sealed class DiscontinuousSByteTests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<DiscontinuousSByteEnum>();
-        max.Should().NotBeNull();
-        max.Should().Be(DiscontinuousSByteEnum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(DiscontinuousSByteEnum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<DiscontinuousSByteEnum>().Should().Be(false);
+        => FastEnum.IsEmpty<DiscontinuousSByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<DiscontinuousSByteEnum>().Should().Be(false);
+        => FastEnum.IsContinuous<DiscontinuousSByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<DiscontinuousSByteEnum>().Should().Be(false);
+        => FastEnum.IsFlags<DiscontinuousSByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<DiscontinuousSByteEnum>(DiscontinuousSByteEnum.A).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousSByteEnum>(DiscontinuousSByteEnum.B).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousSByteEnum>(DiscontinuousSByteEnum.C).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousSByteEnum>((DiscontinuousSByteEnum)123).Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousSByteEnum>(DiscontinuousSByteEnum.A).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousSByteEnum>(DiscontinuousSByteEnum.B).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousSByteEnum>(DiscontinuousSByteEnum.C).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousSByteEnum>((DiscontinuousSByteEnum)123).ShouldBeFalse();
 
         //--- Extension methods
-        DiscontinuousSByteEnum.A.IsDefined().Should().BeTrue();
-        DiscontinuousSByteEnum.B.IsDefined().Should().BeTrue();
-        DiscontinuousSByteEnum.C.IsDefined().Should().BeTrue();
+        DiscontinuousSByteEnum.A.IsDefined().ShouldBeTrue();
+        DiscontinuousSByteEnum.B.IsDefined().ShouldBeTrue();
+        DiscontinuousSByteEnum.C.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<DiscontinuousSByteEnum>(nameof(DiscontinuousSByteEnum.A)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousSByteEnum>(nameof(DiscontinuousSByteEnum.B)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousSByteEnum>(nameof(DiscontinuousSByteEnum.C)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousSByteEnum>("123").Should().BeFalse();
-        FastEnum.IsDefined<DiscontinuousSByteEnum>("value").Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousSByteEnum>(nameof(DiscontinuousSByteEnum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousSByteEnum>(nameof(DiscontinuousSByteEnum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousSByteEnum>(nameof(DiscontinuousSByteEnum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousSByteEnum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<DiscontinuousSByteEnum>("value").ShouldBeFalse();
     }
 
 
@@ -204,18 +204,18 @@ public sealed class DiscontinuousSByteTests
         foreach (var x in parameters)
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousSByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<DiscontinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<DiscontinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousSByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousSByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<DiscontinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<DiscontinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousSByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousSByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousSByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousSByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousSByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousSByteEnum>("123", ignoreCase).Should().Be((DiscontinuousSByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousSByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousSByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousSByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousSByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousSByteEnum>("123", ignoreCase).ShouldBe((DiscontinuousSByteEnum)123);
     }
 
 
@@ -232,18 +232,18 @@ public sealed class DiscontinuousSByteTests
         foreach (var x in parameters)
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousSByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousSByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousSByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousSByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousSByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousSByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousSByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousSByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousSByteEnum>("123", ignoreCase).Should().Be((DiscontinuousSByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousSByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousSByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousSByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousSByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousSByteEnum>("123", ignoreCase).ShouldBe((DiscontinuousSByteEnum)123);
     }
 
 
@@ -261,27 +261,27 @@ public sealed class DiscontinuousSByteTests
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousSByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousSByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousSByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousSByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousSByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousSByteEnum)123);
+        FastEnum.TryParse<DiscontinuousSByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousSByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousSByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousSByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousSByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousSByteEnum)123);
     }
 
 
@@ -299,30 +299,30 @@ public sealed class DiscontinuousSByteTests
         {
             var valueString = ((sbyte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousSByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousSByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousSByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousSByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousSByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousSByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousSByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousSByteEnum)123);
+        FastEnum.TryParse<DiscontinuousSByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousSByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousSByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousSByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousSByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousSByteEnum)123);
     }
 
 
@@ -335,20 +335,20 @@ public sealed class DiscontinuousSByteTests
         var member = value.ToMember()!;
         var info = typeof(DiscontinuousSByteEnum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        DiscontinuousSByteEnum.A.ToName().Should().Be(nameof(DiscontinuousSByteEnum.A));
-        DiscontinuousSByteEnum.B.ToName().Should().Be(nameof(DiscontinuousSByteEnum.B));
-        DiscontinuousSByteEnum.C.ToName().Should().Be(nameof(DiscontinuousSByteEnum.C));
+        DiscontinuousSByteEnum.A.ToName().ShouldBe(nameof(DiscontinuousSByteEnum.A));
+        DiscontinuousSByteEnum.B.ToName().ShouldBe(nameof(DiscontinuousSByteEnum.B));
+        DiscontinuousSByteEnum.C.ToName().ShouldBe(nameof(DiscontinuousSByteEnum.C));
     }
 
 
@@ -358,14 +358,14 @@ public sealed class DiscontinuousSByteTests
         var @enum = DiscontinuousSByteEnum.A;
         const sbyte value = 1;
 
-        @enum.ToSByte().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        @enum.ToSByte().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -378,7 +378,7 @@ public sealed class DiscontinuousSByteTests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -390,7 +390,7 @@ public sealed class DiscontinuousByteTests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<DiscontinuousByteEnum>().Should().Be<byte>();
+        => FastEnum.GetUnderlyingType<DiscontinuousByteEnum>().ShouldBe(typeof(byte));
 
 
     [TestMethod]
@@ -398,7 +398,7 @@ public sealed class DiscontinuousByteTests
     {
         var expect = Enum.GetValues<DiscontinuousByteEnum>();
         var actual = FastEnum.GetValues<DiscontinuousByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -407,7 +407,7 @@ public sealed class DiscontinuousByteTests
     {
         var expect = Enum.GetNames<DiscontinuousByteEnum>();
         var actual = FastEnum.GetNames<DiscontinuousByteEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -419,16 +419,16 @@ public sealed class DiscontinuousByteTests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const DiscontinuousByteEnum undefined = (DiscontinuousByteEnum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -448,19 +448,19 @@ public sealed class DiscontinuousByteTests
             .ToArray();
         var actual = FastEnum.GetMembers<DiscontinuousByteEnum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -474,21 +474,21 @@ public sealed class DiscontinuousByteTests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const DiscontinuousByteEnum undefined = (DiscontinuousByteEnum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -508,8 +508,8 @@ public sealed class DiscontinuousByteTests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<DiscontinuousByteEnum>();
-        min.Should().NotBeNull();
-        min.Should().Be(DiscontinuousByteEnum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(DiscontinuousByteEnum.A);
     }
 
 
@@ -517,46 +517,46 @@ public sealed class DiscontinuousByteTests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<DiscontinuousByteEnum>();
-        max.Should().NotBeNull();
-        max.Should().Be(DiscontinuousByteEnum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(DiscontinuousByteEnum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<DiscontinuousByteEnum>().Should().Be(false);
+        => FastEnum.IsEmpty<DiscontinuousByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<DiscontinuousByteEnum>().Should().Be(false);
+        => FastEnum.IsContinuous<DiscontinuousByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<DiscontinuousByteEnum>().Should().Be(false);
+        => FastEnum.IsFlags<DiscontinuousByteEnum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<DiscontinuousByteEnum>(DiscontinuousByteEnum.A).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousByteEnum>(DiscontinuousByteEnum.B).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousByteEnum>(DiscontinuousByteEnum.C).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousByteEnum>((DiscontinuousByteEnum)123).Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousByteEnum>(DiscontinuousByteEnum.A).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousByteEnum>(DiscontinuousByteEnum.B).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousByteEnum>(DiscontinuousByteEnum.C).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousByteEnum>((DiscontinuousByteEnum)123).ShouldBeFalse();
 
         //--- Extension methods
-        DiscontinuousByteEnum.A.IsDefined().Should().BeTrue();
-        DiscontinuousByteEnum.B.IsDefined().Should().BeTrue();
-        DiscontinuousByteEnum.C.IsDefined().Should().BeTrue();
+        DiscontinuousByteEnum.A.IsDefined().ShouldBeTrue();
+        DiscontinuousByteEnum.B.IsDefined().ShouldBeTrue();
+        DiscontinuousByteEnum.C.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<DiscontinuousByteEnum>(nameof(DiscontinuousByteEnum.A)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousByteEnum>(nameof(DiscontinuousByteEnum.B)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousByteEnum>(nameof(DiscontinuousByteEnum.C)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousByteEnum>("123").Should().BeFalse();
-        FastEnum.IsDefined<DiscontinuousByteEnum>("value").Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousByteEnum>(nameof(DiscontinuousByteEnum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousByteEnum>(nameof(DiscontinuousByteEnum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousByteEnum>(nameof(DiscontinuousByteEnum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousByteEnum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<DiscontinuousByteEnum>("value").ShouldBeFalse();
     }
 
 
@@ -573,18 +573,18 @@ public sealed class DiscontinuousByteTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<DiscontinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<DiscontinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<DiscontinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<DiscontinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousByteEnum>("123", ignoreCase).Should().Be((DiscontinuousByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousByteEnum>("123", ignoreCase).ShouldBe((DiscontinuousByteEnum)123);
     }
 
 
@@ -601,18 +601,18 @@ public sealed class DiscontinuousByteTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousByteEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousByteEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousByteEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousByteEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousByteEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousByteEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousByteEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousByteEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousByteEnum>("123", ignoreCase).Should().Be((DiscontinuousByteEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousByteEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousByteEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousByteEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousByteEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousByteEnum>("123", ignoreCase).ShouldBe((DiscontinuousByteEnum)123);
     }
 
 
@@ -630,27 +630,27 @@ public sealed class DiscontinuousByteTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<DiscontinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<DiscontinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<DiscontinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousByteEnum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousByteEnum)123);
+        FastEnum.TryParse<DiscontinuousByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousByteEnum)123);
     }
 
 
@@ -668,30 +668,30 @@ public sealed class DiscontinuousByteTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousByteEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousByteEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousByteEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousByteEnum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousByteEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousByteEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousByteEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousByteEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousByteEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousByteEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousByteEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousByteEnum)123);
+        FastEnum.TryParse<DiscontinuousByteEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousByteEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousByteEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousByteEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousByteEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousByteEnum)123);
     }
 
 
@@ -704,20 +704,20 @@ public sealed class DiscontinuousByteTests
         var member = value.ToMember()!;
         var info = typeof(DiscontinuousByteEnum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        DiscontinuousByteEnum.A.ToName().Should().Be(nameof(DiscontinuousByteEnum.A));
-        DiscontinuousByteEnum.B.ToName().Should().Be(nameof(DiscontinuousByteEnum.B));
-        DiscontinuousByteEnum.C.ToName().Should().Be(nameof(DiscontinuousByteEnum.C));
+        DiscontinuousByteEnum.A.ToName().ShouldBe(nameof(DiscontinuousByteEnum.A));
+        DiscontinuousByteEnum.B.ToName().ShouldBe(nameof(DiscontinuousByteEnum.B));
+        DiscontinuousByteEnum.C.ToName().ShouldBe(nameof(DiscontinuousByteEnum.C));
     }
 
 
@@ -727,14 +727,14 @@ public sealed class DiscontinuousByteTests
         var @enum = DiscontinuousByteEnum.A;
         const byte value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        @enum.ToByte().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        @enum.ToByte().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -747,7 +747,7 @@ public sealed class DiscontinuousByteTests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -759,7 +759,7 @@ public sealed class DiscontinuousInt16Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<DiscontinuousInt16Enum>().Should().Be<short>();
+        => FastEnum.GetUnderlyingType<DiscontinuousInt16Enum>().ShouldBe(typeof(short));
 
 
     [TestMethod]
@@ -767,7 +767,7 @@ public sealed class DiscontinuousInt16Tests
     {
         var expect = Enum.GetValues<DiscontinuousInt16Enum>();
         var actual = FastEnum.GetValues<DiscontinuousInt16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -776,7 +776,7 @@ public sealed class DiscontinuousInt16Tests
     {
         var expect = Enum.GetNames<DiscontinuousInt16Enum>();
         var actual = FastEnum.GetNames<DiscontinuousInt16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -788,16 +788,16 @@ public sealed class DiscontinuousInt16Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const DiscontinuousInt16Enum undefined = (DiscontinuousInt16Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -817,19 +817,19 @@ public sealed class DiscontinuousInt16Tests
             .ToArray();
         var actual = FastEnum.GetMembers<DiscontinuousInt16Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -843,21 +843,21 @@ public sealed class DiscontinuousInt16Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const DiscontinuousInt16Enum undefined = (DiscontinuousInt16Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -877,8 +877,8 @@ public sealed class DiscontinuousInt16Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<DiscontinuousInt16Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(DiscontinuousInt16Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(DiscontinuousInt16Enum.A);
     }
 
 
@@ -886,46 +886,46 @@ public sealed class DiscontinuousInt16Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<DiscontinuousInt16Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(DiscontinuousInt16Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(DiscontinuousInt16Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<DiscontinuousInt16Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<DiscontinuousInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<DiscontinuousInt16Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<DiscontinuousInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<DiscontinuousInt16Enum>().Should().Be(false);
+        => FastEnum.IsFlags<DiscontinuousInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<DiscontinuousInt16Enum>(DiscontinuousInt16Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt16Enum>(DiscontinuousInt16Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt16Enum>(DiscontinuousInt16Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt16Enum>((DiscontinuousInt16Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousInt16Enum>(DiscontinuousInt16Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt16Enum>(DiscontinuousInt16Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt16Enum>(DiscontinuousInt16Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt16Enum>((DiscontinuousInt16Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        DiscontinuousInt16Enum.A.IsDefined().Should().BeTrue();
-        DiscontinuousInt16Enum.B.IsDefined().Should().BeTrue();
-        DiscontinuousInt16Enum.C.IsDefined().Should().BeTrue();
+        DiscontinuousInt16Enum.A.IsDefined().ShouldBeTrue();
+        DiscontinuousInt16Enum.B.IsDefined().ShouldBeTrue();
+        DiscontinuousInt16Enum.C.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<DiscontinuousInt16Enum>(nameof(DiscontinuousInt16Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt16Enum>(nameof(DiscontinuousInt16Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt16Enum>(nameof(DiscontinuousInt16Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt16Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<DiscontinuousInt16Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousInt16Enum>(nameof(DiscontinuousInt16Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt16Enum>(nameof(DiscontinuousInt16Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt16Enum>(nameof(DiscontinuousInt16Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt16Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<DiscontinuousInt16Enum>("value").ShouldBeFalse();
     }
 
 
@@ -942,18 +942,18 @@ public sealed class DiscontinuousInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousInt16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<DiscontinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<DiscontinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousInt16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<DiscontinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<DiscontinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousInt16Enum>("123", ignoreCase).Should().Be((DiscontinuousInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousInt16Enum>("123", ignoreCase).ShouldBe((DiscontinuousInt16Enum)123);
     }
 
 
@@ -970,18 +970,18 @@ public sealed class DiscontinuousInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousInt16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousInt16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousInt16Enum>("123", ignoreCase).Should().Be((DiscontinuousInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousInt16Enum>("123", ignoreCase).ShouldBe((DiscontinuousInt16Enum)123);
     }
 
 
@@ -999,27 +999,27 @@ public sealed class DiscontinuousInt16Tests
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousInt16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousInt16Enum)123);
+        FastEnum.TryParse<DiscontinuousInt16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousInt16Enum)123);
     }
 
 
@@ -1037,30 +1037,30 @@ public sealed class DiscontinuousInt16Tests
         {
             var valueString = ((short)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousInt16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousInt16Enum)123);
+        FastEnum.TryParse<DiscontinuousInt16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousInt16Enum)123);
     }
 
 
@@ -1073,20 +1073,20 @@ public sealed class DiscontinuousInt16Tests
         var member = value.ToMember()!;
         var info = typeof(DiscontinuousInt16Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        DiscontinuousInt16Enum.A.ToName().Should().Be(nameof(DiscontinuousInt16Enum.A));
-        DiscontinuousInt16Enum.B.ToName().Should().Be(nameof(DiscontinuousInt16Enum.B));
-        DiscontinuousInt16Enum.C.ToName().Should().Be(nameof(DiscontinuousInt16Enum.C));
+        DiscontinuousInt16Enum.A.ToName().ShouldBe(nameof(DiscontinuousInt16Enum.A));
+        DiscontinuousInt16Enum.B.ToName().ShouldBe(nameof(DiscontinuousInt16Enum.B));
+        DiscontinuousInt16Enum.C.ToName().ShouldBe(nameof(DiscontinuousInt16Enum.C));
     }
 
 
@@ -1096,14 +1096,14 @@ public sealed class DiscontinuousInt16Tests
         var @enum = DiscontinuousInt16Enum.A;
         const short value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        @enum.ToInt16().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        @enum.ToInt16().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -1116,7 +1116,7 @@ public sealed class DiscontinuousInt16Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1128,7 +1128,7 @@ public sealed class DiscontinuousUInt16Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<DiscontinuousUInt16Enum>().Should().Be<ushort>();
+        => FastEnum.GetUnderlyingType<DiscontinuousUInt16Enum>().ShouldBe(typeof(ushort));
 
 
     [TestMethod]
@@ -1136,7 +1136,7 @@ public sealed class DiscontinuousUInt16Tests
     {
         var expect = Enum.GetValues<DiscontinuousUInt16Enum>();
         var actual = FastEnum.GetValues<DiscontinuousUInt16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1145,7 +1145,7 @@ public sealed class DiscontinuousUInt16Tests
     {
         var expect = Enum.GetNames<DiscontinuousUInt16Enum>();
         var actual = FastEnum.GetNames<DiscontinuousUInt16Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1157,16 +1157,16 @@ public sealed class DiscontinuousUInt16Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const DiscontinuousUInt16Enum undefined = (DiscontinuousUInt16Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1186,19 +1186,19 @@ public sealed class DiscontinuousUInt16Tests
             .ToArray();
         var actual = FastEnum.GetMembers<DiscontinuousUInt16Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -1212,21 +1212,21 @@ public sealed class DiscontinuousUInt16Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const DiscontinuousUInt16Enum undefined = (DiscontinuousUInt16Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -1246,8 +1246,8 @@ public sealed class DiscontinuousUInt16Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<DiscontinuousUInt16Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(DiscontinuousUInt16Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(DiscontinuousUInt16Enum.A);
     }
 
 
@@ -1255,46 +1255,46 @@ public sealed class DiscontinuousUInt16Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<DiscontinuousUInt16Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(DiscontinuousUInt16Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(DiscontinuousUInt16Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<DiscontinuousUInt16Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<DiscontinuousUInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<DiscontinuousUInt16Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<DiscontinuousUInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<DiscontinuousUInt16Enum>().Should().Be(false);
+        => FastEnum.IsFlags<DiscontinuousUInt16Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<DiscontinuousUInt16Enum>(DiscontinuousUInt16Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt16Enum>(DiscontinuousUInt16Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt16Enum>(DiscontinuousUInt16Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt16Enum>((DiscontinuousUInt16Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousUInt16Enum>(DiscontinuousUInt16Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt16Enum>(DiscontinuousUInt16Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt16Enum>(DiscontinuousUInt16Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt16Enum>((DiscontinuousUInt16Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        DiscontinuousUInt16Enum.A.IsDefined().Should().BeTrue();
-        DiscontinuousUInt16Enum.B.IsDefined().Should().BeTrue();
-        DiscontinuousUInt16Enum.C.IsDefined().Should().BeTrue();
+        DiscontinuousUInt16Enum.A.IsDefined().ShouldBeTrue();
+        DiscontinuousUInt16Enum.B.IsDefined().ShouldBeTrue();
+        DiscontinuousUInt16Enum.C.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<DiscontinuousUInt16Enum>(nameof(DiscontinuousUInt16Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt16Enum>(nameof(DiscontinuousUInt16Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt16Enum>(nameof(DiscontinuousUInt16Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt16Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<DiscontinuousUInt16Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousUInt16Enum>(nameof(DiscontinuousUInt16Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt16Enum>(nameof(DiscontinuousUInt16Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt16Enum>(nameof(DiscontinuousUInt16Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt16Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<DiscontinuousUInt16Enum>("value").ShouldBeFalse();
     }
 
 
@@ -1311,18 +1311,18 @@ public sealed class DiscontinuousUInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousUInt16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<DiscontinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<DiscontinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousUInt16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<DiscontinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<DiscontinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousUInt16Enum>("123", ignoreCase).Should().Be((DiscontinuousUInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousUInt16Enum>("123", ignoreCase).ShouldBe((DiscontinuousUInt16Enum)123);
     }
 
 
@@ -1339,18 +1339,18 @@ public sealed class DiscontinuousUInt16Tests
         foreach (var x in parameters)
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousUInt16Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousUInt16Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt16Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt16Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt16Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt16Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousUInt16Enum>("123", ignoreCase).Should().Be((DiscontinuousUInt16Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt16Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt16Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt16Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt16Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousUInt16Enum>("123", ignoreCase).ShouldBe((DiscontinuousUInt16Enum)123);
     }
 
 
@@ -1368,27 +1368,27 @@ public sealed class DiscontinuousUInt16Tests
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousUInt16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousUInt16Enum)123);
+        FastEnum.TryParse<DiscontinuousUInt16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousUInt16Enum)123);
     }
 
 
@@ -1406,30 +1406,30 @@ public sealed class DiscontinuousUInt16Tests
         {
             var valueString = ((ushort)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt16Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousUInt16Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt16Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt16Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt16Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt16Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousUInt16Enum)123);
+        FastEnum.TryParse<DiscontinuousUInt16Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt16Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt16Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt16Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt16Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousUInt16Enum)123);
     }
 
 
@@ -1442,20 +1442,20 @@ public sealed class DiscontinuousUInt16Tests
         var member = value.ToMember()!;
         var info = typeof(DiscontinuousUInt16Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        DiscontinuousUInt16Enum.A.ToName().Should().Be(nameof(DiscontinuousUInt16Enum.A));
-        DiscontinuousUInt16Enum.B.ToName().Should().Be(nameof(DiscontinuousUInt16Enum.B));
-        DiscontinuousUInt16Enum.C.ToName().Should().Be(nameof(DiscontinuousUInt16Enum.C));
+        DiscontinuousUInt16Enum.A.ToName().ShouldBe(nameof(DiscontinuousUInt16Enum.A));
+        DiscontinuousUInt16Enum.B.ToName().ShouldBe(nameof(DiscontinuousUInt16Enum.B));
+        DiscontinuousUInt16Enum.C.ToName().ShouldBe(nameof(DiscontinuousUInt16Enum.C));
     }
 
 
@@ -1465,14 +1465,14 @@ public sealed class DiscontinuousUInt16Tests
         var @enum = DiscontinuousUInt16Enum.A;
         const ushort value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        @enum.ToUInt16().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        @enum.ToUInt16().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -1485,7 +1485,7 @@ public sealed class DiscontinuousUInt16Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1497,7 +1497,7 @@ public sealed class DiscontinuousInt32Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<DiscontinuousInt32Enum>().Should().Be<int>();
+        => FastEnum.GetUnderlyingType<DiscontinuousInt32Enum>().ShouldBe(typeof(int));
 
 
     [TestMethod]
@@ -1505,7 +1505,7 @@ public sealed class DiscontinuousInt32Tests
     {
         var expect = Enum.GetValues<DiscontinuousInt32Enum>();
         var actual = FastEnum.GetValues<DiscontinuousInt32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1514,7 +1514,7 @@ public sealed class DiscontinuousInt32Tests
     {
         var expect = Enum.GetNames<DiscontinuousInt32Enum>();
         var actual = FastEnum.GetNames<DiscontinuousInt32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1526,16 +1526,16 @@ public sealed class DiscontinuousInt32Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const DiscontinuousInt32Enum undefined = (DiscontinuousInt32Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1555,19 +1555,19 @@ public sealed class DiscontinuousInt32Tests
             .ToArray();
         var actual = FastEnum.GetMembers<DiscontinuousInt32Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -1581,21 +1581,21 @@ public sealed class DiscontinuousInt32Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const DiscontinuousInt32Enum undefined = (DiscontinuousInt32Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -1615,8 +1615,8 @@ public sealed class DiscontinuousInt32Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<DiscontinuousInt32Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(DiscontinuousInt32Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(DiscontinuousInt32Enum.A);
     }
 
 
@@ -1624,46 +1624,46 @@ public sealed class DiscontinuousInt32Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<DiscontinuousInt32Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(DiscontinuousInt32Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(DiscontinuousInt32Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<DiscontinuousInt32Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<DiscontinuousInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<DiscontinuousInt32Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<DiscontinuousInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<DiscontinuousInt32Enum>().Should().Be(false);
+        => FastEnum.IsFlags<DiscontinuousInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<DiscontinuousInt32Enum>(DiscontinuousInt32Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt32Enum>(DiscontinuousInt32Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt32Enum>(DiscontinuousInt32Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt32Enum>((DiscontinuousInt32Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousInt32Enum>(DiscontinuousInt32Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt32Enum>(DiscontinuousInt32Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt32Enum>(DiscontinuousInt32Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt32Enum>((DiscontinuousInt32Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        DiscontinuousInt32Enum.A.IsDefined().Should().BeTrue();
-        DiscontinuousInt32Enum.B.IsDefined().Should().BeTrue();
-        DiscontinuousInt32Enum.C.IsDefined().Should().BeTrue();
+        DiscontinuousInt32Enum.A.IsDefined().ShouldBeTrue();
+        DiscontinuousInt32Enum.B.IsDefined().ShouldBeTrue();
+        DiscontinuousInt32Enum.C.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<DiscontinuousInt32Enum>(nameof(DiscontinuousInt32Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt32Enum>(nameof(DiscontinuousInt32Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt32Enum>(nameof(DiscontinuousInt32Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt32Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<DiscontinuousInt32Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousInt32Enum>(nameof(DiscontinuousInt32Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt32Enum>(nameof(DiscontinuousInt32Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt32Enum>(nameof(DiscontinuousInt32Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt32Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<DiscontinuousInt32Enum>("value").ShouldBeFalse();
     }
 
 
@@ -1680,18 +1680,18 @@ public sealed class DiscontinuousInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousInt32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<DiscontinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<DiscontinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousInt32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<DiscontinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<DiscontinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousInt32Enum>("123", ignoreCase).Should().Be((DiscontinuousInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousInt32Enum>("123", ignoreCase).ShouldBe((DiscontinuousInt32Enum)123);
     }
 
 
@@ -1708,18 +1708,18 @@ public sealed class DiscontinuousInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousInt32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousInt32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousInt32Enum>("123", ignoreCase).Should().Be((DiscontinuousInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousInt32Enum>("123", ignoreCase).ShouldBe((DiscontinuousInt32Enum)123);
     }
 
 
@@ -1737,27 +1737,27 @@ public sealed class DiscontinuousInt32Tests
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousInt32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousInt32Enum)123);
+        FastEnum.TryParse<DiscontinuousInt32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousInt32Enum)123);
     }
 
 
@@ -1775,30 +1775,30 @@ public sealed class DiscontinuousInt32Tests
         {
             var valueString = ((int)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousInt32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousInt32Enum)123);
+        FastEnum.TryParse<DiscontinuousInt32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousInt32Enum)123);
     }
 
 
@@ -1811,20 +1811,20 @@ public sealed class DiscontinuousInt32Tests
         var member = value.ToMember()!;
         var info = typeof(DiscontinuousInt32Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        DiscontinuousInt32Enum.A.ToName().Should().Be(nameof(DiscontinuousInt32Enum.A));
-        DiscontinuousInt32Enum.B.ToName().Should().Be(nameof(DiscontinuousInt32Enum.B));
-        DiscontinuousInt32Enum.C.ToName().Should().Be(nameof(DiscontinuousInt32Enum.C));
+        DiscontinuousInt32Enum.A.ToName().ShouldBe(nameof(DiscontinuousInt32Enum.A));
+        DiscontinuousInt32Enum.B.ToName().ShouldBe(nameof(DiscontinuousInt32Enum.B));
+        DiscontinuousInt32Enum.C.ToName().ShouldBe(nameof(DiscontinuousInt32Enum.C));
     }
 
 
@@ -1834,14 +1834,14 @@ public sealed class DiscontinuousInt32Tests
         var @enum = DiscontinuousInt32Enum.A;
         const int value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        @enum.ToInt32().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        @enum.ToInt32().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -1854,7 +1854,7 @@ public sealed class DiscontinuousInt32Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -1866,7 +1866,7 @@ public sealed class DiscontinuousUInt32Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<DiscontinuousUInt32Enum>().Should().Be<uint>();
+        => FastEnum.GetUnderlyingType<DiscontinuousUInt32Enum>().ShouldBe(typeof(uint));
 
 
     [TestMethod]
@@ -1874,7 +1874,7 @@ public sealed class DiscontinuousUInt32Tests
     {
         var expect = Enum.GetValues<DiscontinuousUInt32Enum>();
         var actual = FastEnum.GetValues<DiscontinuousUInt32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1883,7 +1883,7 @@ public sealed class DiscontinuousUInt32Tests
     {
         var expect = Enum.GetNames<DiscontinuousUInt32Enum>();
         var actual = FastEnum.GetNames<DiscontinuousUInt32Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -1895,16 +1895,16 @@ public sealed class DiscontinuousUInt32Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const DiscontinuousUInt32Enum undefined = (DiscontinuousUInt32Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -1924,19 +1924,19 @@ public sealed class DiscontinuousUInt32Tests
             .ToArray();
         var actual = FastEnum.GetMembers<DiscontinuousUInt32Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -1950,21 +1950,21 @@ public sealed class DiscontinuousUInt32Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const DiscontinuousUInt32Enum undefined = (DiscontinuousUInt32Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -1984,8 +1984,8 @@ public sealed class DiscontinuousUInt32Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<DiscontinuousUInt32Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(DiscontinuousUInt32Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(DiscontinuousUInt32Enum.A);
     }
 
 
@@ -1993,46 +1993,46 @@ public sealed class DiscontinuousUInt32Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<DiscontinuousUInt32Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(DiscontinuousUInt32Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(DiscontinuousUInt32Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<DiscontinuousUInt32Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<DiscontinuousUInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<DiscontinuousUInt32Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<DiscontinuousUInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<DiscontinuousUInt32Enum>().Should().Be(false);
+        => FastEnum.IsFlags<DiscontinuousUInt32Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<DiscontinuousUInt32Enum>(DiscontinuousUInt32Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt32Enum>(DiscontinuousUInt32Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt32Enum>(DiscontinuousUInt32Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt32Enum>((DiscontinuousUInt32Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousUInt32Enum>(DiscontinuousUInt32Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt32Enum>(DiscontinuousUInt32Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt32Enum>(DiscontinuousUInt32Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt32Enum>((DiscontinuousUInt32Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        DiscontinuousUInt32Enum.A.IsDefined().Should().BeTrue();
-        DiscontinuousUInt32Enum.B.IsDefined().Should().BeTrue();
-        DiscontinuousUInt32Enum.C.IsDefined().Should().BeTrue();
+        DiscontinuousUInt32Enum.A.IsDefined().ShouldBeTrue();
+        DiscontinuousUInt32Enum.B.IsDefined().ShouldBeTrue();
+        DiscontinuousUInt32Enum.C.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<DiscontinuousUInt32Enum>(nameof(DiscontinuousUInt32Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt32Enum>(nameof(DiscontinuousUInt32Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt32Enum>(nameof(DiscontinuousUInt32Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt32Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<DiscontinuousUInt32Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousUInt32Enum>(nameof(DiscontinuousUInt32Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt32Enum>(nameof(DiscontinuousUInt32Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt32Enum>(nameof(DiscontinuousUInt32Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt32Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<DiscontinuousUInt32Enum>("value").ShouldBeFalse();
     }
 
 
@@ -2049,18 +2049,18 @@ public sealed class DiscontinuousUInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousUInt32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<DiscontinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<DiscontinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousUInt32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<DiscontinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<DiscontinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousUInt32Enum>("123", ignoreCase).Should().Be((DiscontinuousUInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousUInt32Enum>("123", ignoreCase).ShouldBe((DiscontinuousUInt32Enum)123);
     }
 
 
@@ -2077,18 +2077,18 @@ public sealed class DiscontinuousUInt32Tests
         foreach (var x in parameters)
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousUInt32Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousUInt32Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt32Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt32Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt32Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt32Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousUInt32Enum>("123", ignoreCase).Should().Be((DiscontinuousUInt32Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt32Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt32Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt32Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt32Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousUInt32Enum>("123", ignoreCase).ShouldBe((DiscontinuousUInt32Enum)123);
     }
 
 
@@ -2106,27 +2106,27 @@ public sealed class DiscontinuousUInt32Tests
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousUInt32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousUInt32Enum)123);
+        FastEnum.TryParse<DiscontinuousUInt32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousUInt32Enum)123);
     }
 
 
@@ -2144,30 +2144,30 @@ public sealed class DiscontinuousUInt32Tests
         {
             var valueString = ((uint)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt32Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousUInt32Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt32Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt32Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt32Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt32Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousUInt32Enum)123);
+        FastEnum.TryParse<DiscontinuousUInt32Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt32Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt32Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt32Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt32Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousUInt32Enum)123);
     }
 
 
@@ -2180,20 +2180,20 @@ public sealed class DiscontinuousUInt32Tests
         var member = value.ToMember()!;
         var info = typeof(DiscontinuousUInt32Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        DiscontinuousUInt32Enum.A.ToName().Should().Be(nameof(DiscontinuousUInt32Enum.A));
-        DiscontinuousUInt32Enum.B.ToName().Should().Be(nameof(DiscontinuousUInt32Enum.B));
-        DiscontinuousUInt32Enum.C.ToName().Should().Be(nameof(DiscontinuousUInt32Enum.C));
+        DiscontinuousUInt32Enum.A.ToName().ShouldBe(nameof(DiscontinuousUInt32Enum.A));
+        DiscontinuousUInt32Enum.B.ToName().ShouldBe(nameof(DiscontinuousUInt32Enum.B));
+        DiscontinuousUInt32Enum.C.ToName().ShouldBe(nameof(DiscontinuousUInt32Enum.C));
     }
 
 
@@ -2203,14 +2203,14 @@ public sealed class DiscontinuousUInt32Tests
         var @enum = DiscontinuousUInt32Enum.A;
         const uint value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        @enum.ToUInt32().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        @enum.ToUInt32().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -2223,7 +2223,7 @@ public sealed class DiscontinuousUInt32Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -2235,7 +2235,7 @@ public sealed class DiscontinuousInt64Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<DiscontinuousInt64Enum>().Should().Be<long>();
+        => FastEnum.GetUnderlyingType<DiscontinuousInt64Enum>().ShouldBe(typeof(long));
 
 
     [TestMethod]
@@ -2243,7 +2243,7 @@ public sealed class DiscontinuousInt64Tests
     {
         var expect = Enum.GetValues<DiscontinuousInt64Enum>();
         var actual = FastEnum.GetValues<DiscontinuousInt64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2252,7 +2252,7 @@ public sealed class DiscontinuousInt64Tests
     {
         var expect = Enum.GetNames<DiscontinuousInt64Enum>();
         var actual = FastEnum.GetNames<DiscontinuousInt64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2264,16 +2264,16 @@ public sealed class DiscontinuousInt64Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const DiscontinuousInt64Enum undefined = (DiscontinuousInt64Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -2293,19 +2293,19 @@ public sealed class DiscontinuousInt64Tests
             .ToArray();
         var actual = FastEnum.GetMembers<DiscontinuousInt64Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -2319,21 +2319,21 @@ public sealed class DiscontinuousInt64Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const DiscontinuousInt64Enum undefined = (DiscontinuousInt64Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -2353,8 +2353,8 @@ public sealed class DiscontinuousInt64Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<DiscontinuousInt64Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(DiscontinuousInt64Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(DiscontinuousInt64Enum.A);
     }
 
 
@@ -2362,46 +2362,46 @@ public sealed class DiscontinuousInt64Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<DiscontinuousInt64Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(DiscontinuousInt64Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(DiscontinuousInt64Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<DiscontinuousInt64Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<DiscontinuousInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<DiscontinuousInt64Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<DiscontinuousInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<DiscontinuousInt64Enum>().Should().Be(false);
+        => FastEnum.IsFlags<DiscontinuousInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<DiscontinuousInt64Enum>(DiscontinuousInt64Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt64Enum>(DiscontinuousInt64Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt64Enum>(DiscontinuousInt64Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt64Enum>((DiscontinuousInt64Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousInt64Enum>(DiscontinuousInt64Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt64Enum>(DiscontinuousInt64Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt64Enum>(DiscontinuousInt64Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt64Enum>((DiscontinuousInt64Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        DiscontinuousInt64Enum.A.IsDefined().Should().BeTrue();
-        DiscontinuousInt64Enum.B.IsDefined().Should().BeTrue();
-        DiscontinuousInt64Enum.C.IsDefined().Should().BeTrue();
+        DiscontinuousInt64Enum.A.IsDefined().ShouldBeTrue();
+        DiscontinuousInt64Enum.B.IsDefined().ShouldBeTrue();
+        DiscontinuousInt64Enum.C.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<DiscontinuousInt64Enum>(nameof(DiscontinuousInt64Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt64Enum>(nameof(DiscontinuousInt64Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt64Enum>(nameof(DiscontinuousInt64Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousInt64Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<DiscontinuousInt64Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousInt64Enum>(nameof(DiscontinuousInt64Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt64Enum>(nameof(DiscontinuousInt64Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt64Enum>(nameof(DiscontinuousInt64Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousInt64Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<DiscontinuousInt64Enum>("value").ShouldBeFalse();
     }
 
 
@@ -2418,18 +2418,18 @@ public sealed class DiscontinuousInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousInt64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<DiscontinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<DiscontinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousInt64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<DiscontinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<DiscontinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousInt64Enum>("123", ignoreCase).Should().Be((DiscontinuousInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousInt64Enum>("123", ignoreCase).ShouldBe((DiscontinuousInt64Enum)123);
     }
 
 
@@ -2446,18 +2446,18 @@ public sealed class DiscontinuousInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousInt64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousInt64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousInt64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousInt64Enum>("123", ignoreCase).Should().Be((DiscontinuousInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousInt64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousInt64Enum>("123", ignoreCase).ShouldBe((DiscontinuousInt64Enum)123);
     }
 
 
@@ -2475,27 +2475,27 @@ public sealed class DiscontinuousInt64Tests
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousInt64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousInt64Enum)123);
+        FastEnum.TryParse<DiscontinuousInt64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousInt64Enum)123);
     }
 
 
@@ -2513,30 +2513,30 @@ public sealed class DiscontinuousInt64Tests
         {
             var valueString = ((long)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousInt64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousInt64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousInt64Enum)123);
+        FastEnum.TryParse<DiscontinuousInt64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousInt64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousInt64Enum)123);
     }
 
 
@@ -2549,20 +2549,20 @@ public sealed class DiscontinuousInt64Tests
         var member = value.ToMember()!;
         var info = typeof(DiscontinuousInt64Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        DiscontinuousInt64Enum.A.ToName().Should().Be(nameof(DiscontinuousInt64Enum.A));
-        DiscontinuousInt64Enum.B.ToName().Should().Be(nameof(DiscontinuousInt64Enum.B));
-        DiscontinuousInt64Enum.C.ToName().Should().Be(nameof(DiscontinuousInt64Enum.C));
+        DiscontinuousInt64Enum.A.ToName().ShouldBe(nameof(DiscontinuousInt64Enum.A));
+        DiscontinuousInt64Enum.B.ToName().ShouldBe(nameof(DiscontinuousInt64Enum.B));
+        DiscontinuousInt64Enum.C.ToName().ShouldBe(nameof(DiscontinuousInt64Enum.C));
     }
 
 
@@ -2572,14 +2572,14 @@ public sealed class DiscontinuousInt64Tests
         var @enum = DiscontinuousInt64Enum.A;
         const long value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        @enum.ToInt64().Should().Be(value);
-        FluentActions.Invoking(() => @enum.ToUInt64()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        @enum.ToInt64().ShouldBe(value);
+        Should.Throw<ArgumentException>(() => @enum.ToUInt64());
     }
 
 
@@ -2592,7 +2592,7 @@ public sealed class DiscontinuousInt64Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -2604,7 +2604,7 @@ public sealed class DiscontinuousUInt64Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<DiscontinuousUInt64Enum>().Should().Be<ulong>();
+        => FastEnum.GetUnderlyingType<DiscontinuousUInt64Enum>().ShouldBe(typeof(ulong));
 
 
     [TestMethod]
@@ -2612,7 +2612,7 @@ public sealed class DiscontinuousUInt64Tests
     {
         var expect = Enum.GetValues<DiscontinuousUInt64Enum>();
         var actual = FastEnum.GetValues<DiscontinuousUInt64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2621,7 +2621,7 @@ public sealed class DiscontinuousUInt64Tests
     {
         var expect = Enum.GetNames<DiscontinuousUInt64Enum>();
         var actual = FastEnum.GetNames<DiscontinuousUInt64Enum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -2633,16 +2633,16 @@ public sealed class DiscontinuousUInt64Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const DiscontinuousUInt64Enum undefined = (DiscontinuousUInt64Enum)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -2662,19 +2662,19 @@ public sealed class DiscontinuousUInt64Tests
             .ToArray();
         var actual = FastEnum.GetMembers<DiscontinuousUInt64Enum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -2688,21 +2688,21 @@ public sealed class DiscontinuousUInt64Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const DiscontinuousUInt64Enum undefined = (DiscontinuousUInt64Enum)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -2722,8 +2722,8 @@ public sealed class DiscontinuousUInt64Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<DiscontinuousUInt64Enum>();
-        min.Should().NotBeNull();
-        min.Should().Be(DiscontinuousUInt64Enum.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(DiscontinuousUInt64Enum.A);
     }
 
 
@@ -2731,46 +2731,46 @@ public sealed class DiscontinuousUInt64Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<DiscontinuousUInt64Enum>();
-        max.Should().NotBeNull();
-        max.Should().Be(DiscontinuousUInt64Enum.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(DiscontinuousUInt64Enum.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<DiscontinuousUInt64Enum>().Should().Be(false);
+        => FastEnum.IsEmpty<DiscontinuousUInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<DiscontinuousUInt64Enum>().Should().Be(false);
+        => FastEnum.IsContinuous<DiscontinuousUInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<DiscontinuousUInt64Enum>().Should().Be(false);
+        => FastEnum.IsFlags<DiscontinuousUInt64Enum>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<DiscontinuousUInt64Enum>(DiscontinuousUInt64Enum.A).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt64Enum>(DiscontinuousUInt64Enum.B).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt64Enum>(DiscontinuousUInt64Enum.C).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt64Enum>((DiscontinuousUInt64Enum)123).Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousUInt64Enum>(DiscontinuousUInt64Enum.A).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt64Enum>(DiscontinuousUInt64Enum.B).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt64Enum>(DiscontinuousUInt64Enum.C).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt64Enum>((DiscontinuousUInt64Enum)123).ShouldBeFalse();
 
         //--- Extension methods
-        DiscontinuousUInt64Enum.A.IsDefined().Should().BeTrue();
-        DiscontinuousUInt64Enum.B.IsDefined().Should().BeTrue();
-        DiscontinuousUInt64Enum.C.IsDefined().Should().BeTrue();
+        DiscontinuousUInt64Enum.A.IsDefined().ShouldBeTrue();
+        DiscontinuousUInt64Enum.B.IsDefined().ShouldBeTrue();
+        DiscontinuousUInt64Enum.C.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<DiscontinuousUInt64Enum>(nameof(DiscontinuousUInt64Enum.A)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt64Enum>(nameof(DiscontinuousUInt64Enum.B)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt64Enum>(nameof(DiscontinuousUInt64Enum.C)).Should().BeTrue();
-        FastEnum.IsDefined<DiscontinuousUInt64Enum>("123").Should().BeFalse();
-        FastEnum.IsDefined<DiscontinuousUInt64Enum>("value").Should().BeFalse();
+        FastEnum.IsDefined<DiscontinuousUInt64Enum>(nameof(DiscontinuousUInt64Enum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt64Enum>(nameof(DiscontinuousUInt64Enum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt64Enum>(nameof(DiscontinuousUInt64Enum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<DiscontinuousUInt64Enum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<DiscontinuousUInt64Enum>("value").ShouldBeFalse();
     }
 
 
@@ -2787,18 +2787,18 @@ public sealed class DiscontinuousUInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousUInt64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<DiscontinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<DiscontinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousUInt64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<DiscontinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<DiscontinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousUInt64Enum>("123", ignoreCase).Should().Be((DiscontinuousUInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousUInt64Enum>("123", ignoreCase).ShouldBe((DiscontinuousUInt64Enum)123);
     }
 
 
@@ -2815,18 +2815,18 @@ public sealed class DiscontinuousUInt64Tests
         foreach (var x in parameters)
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<DiscontinuousUInt64Enum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<DiscontinuousUInt64Enum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<DiscontinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt64Enum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt64Enum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt64Enum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<DiscontinuousUInt64Enum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<DiscontinuousUInt64Enum>("123", ignoreCase).Should().Be((DiscontinuousUInt64Enum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt64Enum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt64Enum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt64Enum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<DiscontinuousUInt64Enum>("ABCDE", ignoreCase));
+        FastEnum.Parse<DiscontinuousUInt64Enum>("123", ignoreCase).ShouldBe((DiscontinuousUInt64Enum)123);
     }
 
 
@@ -2844,27 +2844,27 @@ public sealed class DiscontinuousUInt64Tests
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousUInt64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousUInt64Enum)123);
+        FastEnum.TryParse<DiscontinuousUInt64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousUInt64Enum)123);
     }
 
 
@@ -2882,30 +2882,30 @@ public sealed class DiscontinuousUInt64Tests
         {
             var valueString = ((ulong)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<DiscontinuousUInt64Enum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<DiscontinuousUInt64Enum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt64Enum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt64Enum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt64Enum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<DiscontinuousUInt64Enum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((DiscontinuousUInt64Enum)123);
+        FastEnum.TryParse<DiscontinuousUInt64Enum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt64Enum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt64Enum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt64Enum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<DiscontinuousUInt64Enum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((DiscontinuousUInt64Enum)123);
     }
 
 
@@ -2918,20 +2918,20 @@ public sealed class DiscontinuousUInt64Tests
         var member = value.ToMember()!;
         var info = typeof(DiscontinuousUInt64Enum).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        DiscontinuousUInt64Enum.A.ToName().Should().Be(nameof(DiscontinuousUInt64Enum.A));
-        DiscontinuousUInt64Enum.B.ToName().Should().Be(nameof(DiscontinuousUInt64Enum.B));
-        DiscontinuousUInt64Enum.C.ToName().Should().Be(nameof(DiscontinuousUInt64Enum.C));
+        DiscontinuousUInt64Enum.A.ToName().ShouldBe(nameof(DiscontinuousUInt64Enum.A));
+        DiscontinuousUInt64Enum.B.ToName().ShouldBe(nameof(DiscontinuousUInt64Enum.B));
+        DiscontinuousUInt64Enum.C.ToName().ShouldBe(nameof(DiscontinuousUInt64Enum.C));
     }
 
 
@@ -2941,14 +2941,14 @@ public sealed class DiscontinuousUInt64Tests
         var @enum = DiscontinuousUInt64Enum.A;
         const ulong value = 1;
 
-        FluentActions.Invoking(() => @enum.ToSByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToByte()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt16()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToUInt32()).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(() => @enum.ToInt64()).Should().Throw<ArgumentException>();
-        @enum.ToUInt64().Should().Be(value);
+        Should.Throw<ArgumentException>(() => @enum.ToSByte());
+        Should.Throw<ArgumentException>(() => @enum.ToByte());
+        Should.Throw<ArgumentException>(() => @enum.ToInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt16());
+        Should.Throw<ArgumentException>(() => @enum.ToInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToUInt32());
+        Should.Throw<ArgumentException>(() => @enum.ToInt64());
+        @enum.ToUInt64().ShouldBe(value);
     }
 
 
@@ -2961,7 +2961,7 @@ public sealed class DiscontinuousUInt64Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/DiscontinuousTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/DiscontinuousTests.tt
@@ -27,8 +27,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
 
@@ -40,7 +40,7 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
 {
     [TestMethod]
     public void GetUnderlyingType()
-        => FastEnum.GetUnderlyingType<<#= x.EnumType #>>().Should().Be<<#= x.UnderlyingType #>>();
+        => FastEnum.GetUnderlyingType<<#= x.EnumType #>>().ShouldBe(typeof(<#= x.UnderlyingType #>));
 
 
     [TestMethod]
@@ -48,7 +48,7 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
     {
         var expect = Enum.GetValues<<#= x.EnumType #>>();
         var actual = FastEnum.GetValues<<#= x.EnumType #>>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -57,7 +57,7 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
     {
         var expect = Enum.GetNames<<#= x.EnumType #>>();
         var actual = FastEnum.GetNames<<#= x.EnumType #>>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -69,16 +69,16 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
         {
             var expect = Enum.GetName(defined);
             var actual = FastEnum.GetName(defined);
-            actual.Should().NotBeNull();
-            actual.Should().Be(expect);
+            actual.ShouldNotBeNull();
+            actual.ShouldBe(expect);
         }
         //--- undefined value
         {
             const <#= x.EnumType #> undefined = (<#= x.EnumType #>)123;
             var expect = Enum.GetName(undefined);
             var actual = FastEnum.GetName(undefined);
-            actual.Should().BeNull();
-            actual.Should().Be(expect);
+            actual.ShouldBeNull();
+            actual.ShouldBe(expect);
         }
     }
 
@@ -98,19 +98,19 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
             .ToArray();
         var actual = FastEnum.GetMembers<<#= x.EnumType #>>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -124,21 +124,21 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
             var expect = getMember(defined);
             var actual = FastEnum.GetMember(defined)!;
 
-            actual.Should().NotBeNull();
-            actual.Value.Should().Be(expect.value);
-            actual.Name.Should().Be(expect.name);
-            actual.NameUtf8.Should().Equal(expect.nameUtf8);
-            actual.FieldInfo.Should().Be(expect.fieldInfo);
+            actual.ShouldNotBeNull();
+            actual.Value.ShouldBe(expect.value);
+            actual.Name.ShouldBe(expect.name);
+            actual.NameUtf8.ShouldBe(expect.nameUtf8);
+            actual.FieldInfo.ShouldBe(expect.fieldInfo);
 
             var (name, value) = actual;
-            value.Should().Be(expect.value);
-            name.Should().Be(expect.name);
+            value.ShouldBe(expect.value);
+            name.ShouldBe(expect.name);
         }
         //--- undefined value
         {
             const <#= x.EnumType #> undefined = (<#= x.EnumType #>)123;
             var actual = FastEnum.GetMember(undefined);
-            actual.Should().BeNull();
+            actual.ShouldBeNull();
         }
 
         #region Local Functions
@@ -158,8 +158,8 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
     public void GetMinValue()
     {
         var min = FastEnum.GetMinValue<<#= x.EnumType #>>();
-        min.Should().NotBeNull();
-        min.Should().Be(<#= x.EnumType #>.A);
+        min.ShouldNotBeNull();
+        min.ShouldBe(<#= x.EnumType #>.A);
     }
 
 
@@ -167,46 +167,46 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
     public void GetMaxValue()
     {
         var max = FastEnum.GetMaxValue<<#= x.EnumType #>>();
-        max.Should().NotBeNull();
-        max.Should().Be(<#= x.EnumType #>.C);
+        max.ShouldNotBeNull();
+        max.ShouldBe(<#= x.EnumType #>.C);
     }
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<<#= x.EnumType #>>().Should().Be(false);
+        => FastEnum.IsEmpty<<#= x.EnumType #>>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<<#= x.EnumType #>>().Should().Be(false);
+        => FastEnum.IsContinuous<<#= x.EnumType #>>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsFlags()
-        => FastEnum.IsFlags<<#= x.EnumType #>>().Should().Be(false);
+        => FastEnum.IsFlags<<#= x.EnumType #>>().ShouldBe(false);
 
 
     [TestMethod]
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.A).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.B).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.C).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>((<#= x.EnumType #>)123).Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.A).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.B).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(<#= x.EnumType #>.C).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>((<#= x.EnumType #>)123).ShouldBeFalse();
 
         //--- Extension methods
-        <#= x.EnumType #>.A.IsDefined().Should().BeTrue();
-        <#= x.EnumType #>.B.IsDefined().Should().BeTrue();
-        <#= x.EnumType #>.C.IsDefined().Should().BeTrue();
+        <#= x.EnumType #>.A.IsDefined().ShouldBeTrue();
+        <#= x.EnumType #>.B.IsDefined().ShouldBeTrue();
+        <#= x.EnumType #>.C.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.A)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.B)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.C)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>("123").Should().BeFalse();
-        FastEnum.IsDefined<<#= x.EnumType #>>("value").Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.A)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.B)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.C)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>("123").ShouldBeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>("value").ShouldBeFalse();
     }
 
 
@@ -223,18 +223,18 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -251,18 +251,18 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -280,27 +280,27 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -318,30 +318,30 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -354,20 +354,20 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
         var member = value.ToMember()!;
         var info = typeof(<#= x.EnumType #>).GetField(name);
 
-        member.Should().NotBeNull();
-        member.Name.Should().Be(name);
-        member.NameUtf8.Should().Equal(nameUtf8);
-        member.Value.Should().Be(value);
-        member.FieldInfo.Should().Be(info);
+        member.ShouldNotBeNull();
+        member.Name.ShouldBe(name);
+        member.NameUtf8.ShouldBe(nameUtf8);
+        member.Value.ShouldBe(value);
+        member.FieldInfo.ShouldBe(info);
     }
 
 
     [TestMethod]
     public void ToName()
     {
-        <#= x.EnumType #>.A.ToName().Should().Be(nameof(<#= x.EnumType #>.A));
-        <#= x.EnumType #>.B.ToName().Should().Be(nameof(<#= x.EnumType #>.B));
-        <#= x.EnumType #>.C.ToName().Should().Be(nameof(<#= x.EnumType #>.C));
+        <#= x.EnumType #>.A.ToName().ShouldBe(nameof(<#= x.EnumType #>.A));
+        <#= x.EnumType #>.B.ToName().ShouldBe(nameof(<#= x.EnumType #>.B));
+        <#= x.EnumType #>.C.ToName().ShouldBe(nameof(<#= x.EnumType #>.C));
     }
 
 
@@ -379,9 +379,9 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
 
 <# foreach (var y in parameters) { #>
 <# if (x.EnumType == y.EnumType) { #>
-        @enum.To<#= y.AliasType #>().Should().Be(value);
+        @enum.To<#= y.AliasType #>().ShouldBe(value);
 <# } else { #>
-        FluentActions.Invoking(() => @enum.To<#= y.AliasType #>()).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => @enum.To<#= y.AliasType #>());
 <# } #>
 <# } #>
     }
@@ -396,7 +396,7 @@ public sealed class Discontinuous<#= x.AliasType #>Tests
         {
             var expect = x.ToString();
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/EmptyTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/EmptyTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 using TEnum = FastEnumUtility.UnitTests.Models.EmptyEnum;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
@@ -12,54 +12,54 @@ public class EmptyTests
 {
     [TestMethod]
     public void GetValues()
-        => FastEnum.GetValues<TEnum>().Should().BeEmpty();
+        => FastEnum.GetValues<TEnum>().ShouldBeEmpty();
 
 
     [TestMethod]
     public void GetNames()
-        => FastEnum.GetNames<TEnum>().Should().BeEmpty();
+        => FastEnum.GetNames<TEnum>().ShouldBeEmpty();
 
 
     [TestMethod]
     public void GetName()
-        => FastEnum.GetName<TEnum>(default).Should().BeNull();
+        => FastEnum.GetName<TEnum>(default).ShouldBeNull();
 
 
     [TestMethod]
     public void GetMembers()
-        => FastEnum.GetMembers<TEnum>().Should().BeEmpty();
+        => FastEnum.GetMembers<TEnum>().ShouldBeEmpty();
 
 
     [TestMethod]
     public void GetMember()
-        => FastEnum.GetMember<TEnum>(default).Should().BeNull();
+        => FastEnum.GetMember<TEnum>(default).ShouldBeNull();
 
 
     [TestMethod]
     public void GetMinValue()
-        => FastEnum.GetMinValue<TEnum>().Should().BeNull();
+        => FastEnum.GetMinValue<TEnum>().ShouldBeNull();
 
 
     [TestMethod]
     public void GetMaxValue()
-        => FastEnum.GetMaxValue<TEnum>().Should().BeNull();
+        => FastEnum.GetMaxValue<TEnum>().ShouldBeNull();
 
 
     [TestMethod]
     public void IsEmpty()
-        => FastEnum.IsEmpty<TEnum>().Should().BeTrue();
+        => FastEnum.IsEmpty<TEnum>().ShouldBeTrue();
 
 
     [TestMethod]
     public void IsContinuous()
-        => FastEnum.IsContinuous<TEnum>().Should().BeFalse();
+        => FastEnum.IsContinuous<TEnum>().ShouldBeFalse();
 
 
     [TestMethod]
     public void IsDefined()
     {
-        FastEnum.IsDefined((TEnum)123).Should().BeFalse();
-        FastEnum.IsDefined<TEnum>("123").Should().BeFalse();
+        FastEnum.IsDefined((TEnum)123).ShouldBeFalse();
+        FastEnum.IsDefined<TEnum>("123").ShouldBeFalse();
     }
 
 
@@ -67,11 +67,11 @@ public class EmptyTests
     public void Parse()
     {
         const bool ignoreCase = false;
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<TEnum>("123", ignoreCase).Should().Be((TEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<TEnum>("123", ignoreCase).ShouldBe((TEnum)123);
     }
 
 
@@ -79,11 +79,11 @@ public class EmptyTests
     public void ParseIgnoreCase()
     {
         const bool ignoreCase = true;
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<TEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<TEnum>("123", ignoreCase).Should().Be((TEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<TEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<TEnum>("123", ignoreCase).ShouldBe((TEnum)123);
     }
 
 
@@ -91,12 +91,12 @@ public class EmptyTests
     public void TryParse()
     {
         const bool ignoreCase = false;
-        FastEnum.TryParse<TEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((TEnum)123);
+        FastEnum.TryParse<TEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((TEnum)123);
     }
 
 
@@ -104,12 +104,12 @@ public class EmptyTests
     public void TryParseIgnoreCase()
     {
         const bool ignoreCase = true;
-        FastEnum.TryParse<TEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<TEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((TEnum)123);
+        FastEnum.TryParse<TEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<TEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((TEnum)123);
     }
 
 
@@ -120,7 +120,7 @@ public class EmptyTests
         var expect = undefined.ToString();
         var actual1 = FastEnum.ToString(undefined);
         var actual2 = undefined.FastToString();
-        actual1.Should().Be(expect);
-        actual2.Should().Be(expect);
+        actual1.ShouldBe(expect);
+        actual2.ShouldBe(expect);
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/SameValueTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/SameValueTests.cs
@@ -8,8 +8,8 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
 
@@ -23,7 +23,7 @@ public sealed class SameValueContinuousTests
     {
         var expect = Enum.GetValues<SameValueContinuousEnum>();
         var actual = FastEnum.GetValues<SameValueContinuousEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -32,7 +32,7 @@ public sealed class SameValueContinuousTests
     {
         var expect = Enum.GetNames(typeof(SameValueContinuousEnum));
         var actual = FastEnum.GetNames<SameValueContinuousEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -51,19 +51,19 @@ public sealed class SameValueContinuousTests
             .ToArray();
         var actual = FastEnum.GetMembers<SameValueContinuousEnum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -72,25 +72,25 @@ public sealed class SameValueContinuousTests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined(SameValueContinuousEnum.A).Should().BeTrue();
-        FastEnum.IsDefined(SameValueContinuousEnum.B).Should().BeTrue();
-        FastEnum.IsDefined(SameValueContinuousEnum.C).Should().BeTrue();
-        FastEnum.IsDefined(SameValueContinuousEnum.D).Should().BeTrue();
-        FastEnum.IsDefined((SameValueContinuousEnum)123).Should().BeFalse();
+        FastEnum.IsDefined(SameValueContinuousEnum.A).ShouldBeTrue();
+        FastEnum.IsDefined(SameValueContinuousEnum.B).ShouldBeTrue();
+        FastEnum.IsDefined(SameValueContinuousEnum.C).ShouldBeTrue();
+        FastEnum.IsDefined(SameValueContinuousEnum.D).ShouldBeTrue();
+        FastEnum.IsDefined((SameValueContinuousEnum)123).ShouldBeFalse();
 
         //--- Extension methods
-        SameValueContinuousEnum.A.IsDefined().Should().BeTrue();
-        SameValueContinuousEnum.B.IsDefined().Should().BeTrue();
-        SameValueContinuousEnum.C.IsDefined().Should().BeTrue();
-        SameValueContinuousEnum.D.IsDefined().Should().BeTrue();
+        SameValueContinuousEnum.A.IsDefined().ShouldBeTrue();
+        SameValueContinuousEnum.B.IsDefined().ShouldBeTrue();
+        SameValueContinuousEnum.C.IsDefined().ShouldBeTrue();
+        SameValueContinuousEnum.D.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<SameValueContinuousEnum>(nameof(SameValueContinuousEnum.A)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum>(nameof(SameValueContinuousEnum.B)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum>(nameof(SameValueContinuousEnum.C)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum>(nameof(SameValueContinuousEnum.D)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueContinuousEnum>("123").Should().BeFalse();
-        FastEnum.IsDefined<SameValueContinuousEnum>("value").Should().BeFalse();
+        FastEnum.IsDefined<SameValueContinuousEnum>(nameof(SameValueContinuousEnum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum>(nameof(SameValueContinuousEnum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum>(nameof(SameValueContinuousEnum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum>(nameof(SameValueContinuousEnum.D)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueContinuousEnum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<SameValueContinuousEnum>("value").ShouldBeFalse();
     }
 
 
@@ -108,18 +108,18 @@ public sealed class SameValueContinuousTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SameValueContinuousEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<SameValueContinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<SameValueContinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SameValueContinuousEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<SameValueContinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<SameValueContinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SameValueContinuousEnum>("123", ignoreCase).Should().Be((SameValueContinuousEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<SameValueContinuousEnum>("123", ignoreCase).ShouldBe((SameValueContinuousEnum)123);
     }
 
 
@@ -137,18 +137,18 @@ public sealed class SameValueContinuousTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SameValueContinuousEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueContinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SameValueContinuousEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueContinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueContinuousEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SameValueContinuousEnum>("123", ignoreCase).Should().Be((SameValueContinuousEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueContinuousEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<SameValueContinuousEnum>("123", ignoreCase).ShouldBe((SameValueContinuousEnum)123);
     }
 
 
@@ -167,27 +167,27 @@ public sealed class SameValueContinuousTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SameValueContinuousEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<SameValueContinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<SameValueContinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<SameValueContinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<SameValueContinuousEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SameValueContinuousEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SameValueContinuousEnum)123);
+        FastEnum.TryParse<SameValueContinuousEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SameValueContinuousEnum)123);
     }
 
 
@@ -206,30 +206,30 @@ public sealed class SameValueContinuousTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SameValueContinuousEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueContinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<SameValueContinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SameValueContinuousEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueContinuousEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SameValueContinuousEnum)123);
+        FastEnum.TryParse<SameValueContinuousEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueContinuousEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SameValueContinuousEnum)123);
     }
 
 
@@ -243,11 +243,11 @@ public sealed class SameValueContinuousTests
             var member = value.ToMember()!;
             var info = typeof(SameValueContinuousEnum).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
         {
             var value = SameValueContinuousEnum.B;
@@ -256,11 +256,11 @@ public sealed class SameValueContinuousTests
             var member = value.ToMember()!;
             var info = typeof(SameValueContinuousEnum).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
         {
             var value = SameValueContinuousEnum.C;
@@ -269,11 +269,11 @@ public sealed class SameValueContinuousTests
             var member = value.ToMember()!;
             var info = typeof(SameValueContinuousEnum).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
         {
             var value = SameValueContinuousEnum.D;
@@ -282,11 +282,11 @@ public sealed class SameValueContinuousTests
             var member = value.ToMember()!;
             var info = typeof(SameValueContinuousEnum).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
     }
 
@@ -299,7 +299,7 @@ public sealed class SameValueContinuousTests
         {
             var expect = Enum.GetName(x);
             var actual = x.ToName();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 
@@ -312,7 +312,7 @@ public sealed class SameValueContinuousTests
         {
             var expect = Enum.GetName(x);
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }
@@ -327,7 +327,7 @@ public sealed class SameValueDiscontinuousTests
     {
         var expect = Enum.GetValues<SameValueDiscontinuousEnum>();
         var actual = FastEnum.GetValues<SameValueDiscontinuousEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -336,7 +336,7 @@ public sealed class SameValueDiscontinuousTests
     {
         var expect = Enum.GetNames(typeof(SameValueDiscontinuousEnum));
         var actual = FastEnum.GetNames<SameValueDiscontinuousEnum>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -355,19 +355,19 @@ public sealed class SameValueDiscontinuousTests
             .ToArray();
         var actual = FastEnum.GetMembers<SameValueDiscontinuousEnum>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -376,25 +376,25 @@ public sealed class SameValueDiscontinuousTests
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined(SameValueDiscontinuousEnum.A).Should().BeTrue();
-        FastEnum.IsDefined(SameValueDiscontinuousEnum.B).Should().BeTrue();
-        FastEnum.IsDefined(SameValueDiscontinuousEnum.C).Should().BeTrue();
-        FastEnum.IsDefined(SameValueDiscontinuousEnum.D).Should().BeTrue();
-        FastEnum.IsDefined((SameValueDiscontinuousEnum)123).Should().BeFalse();
+        FastEnum.IsDefined(SameValueDiscontinuousEnum.A).ShouldBeTrue();
+        FastEnum.IsDefined(SameValueDiscontinuousEnum.B).ShouldBeTrue();
+        FastEnum.IsDefined(SameValueDiscontinuousEnum.C).ShouldBeTrue();
+        FastEnum.IsDefined(SameValueDiscontinuousEnum.D).ShouldBeTrue();
+        FastEnum.IsDefined((SameValueDiscontinuousEnum)123).ShouldBeFalse();
 
         //--- Extension methods
-        SameValueDiscontinuousEnum.A.IsDefined().Should().BeTrue();
-        SameValueDiscontinuousEnum.B.IsDefined().Should().BeTrue();
-        SameValueDiscontinuousEnum.C.IsDefined().Should().BeTrue();
-        SameValueDiscontinuousEnum.D.IsDefined().Should().BeTrue();
+        SameValueDiscontinuousEnum.A.IsDefined().ShouldBeTrue();
+        SameValueDiscontinuousEnum.B.IsDefined().ShouldBeTrue();
+        SameValueDiscontinuousEnum.C.IsDefined().ShouldBeTrue();
+        SameValueDiscontinuousEnum.D.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<SameValueDiscontinuousEnum>(nameof(SameValueDiscontinuousEnum.A)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum>(nameof(SameValueDiscontinuousEnum.B)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum>(nameof(SameValueDiscontinuousEnum.C)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum>(nameof(SameValueDiscontinuousEnum.D)).Should().BeTrue();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum>("123").Should().BeFalse();
-        FastEnum.IsDefined<SameValueDiscontinuousEnum>("value").Should().BeFalse();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum>(nameof(SameValueDiscontinuousEnum.A)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum>(nameof(SameValueDiscontinuousEnum.B)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum>(nameof(SameValueDiscontinuousEnum.C)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum>(nameof(SameValueDiscontinuousEnum.D)).ShouldBeTrue();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum>("123").ShouldBeFalse();
+        FastEnum.IsDefined<SameValueDiscontinuousEnum>("value").ShouldBeFalse();
     }
 
 
@@ -412,18 +412,18 @@ public sealed class SameValueDiscontinuousTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SameValueDiscontinuousEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<SameValueDiscontinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<SameValueDiscontinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<SameValueDiscontinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<SameValueDiscontinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SameValueDiscontinuousEnum>("123", ignoreCase).Should().Be((SameValueDiscontinuousEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<SameValueDiscontinuousEnum>("123", ignoreCase).ShouldBe((SameValueDiscontinuousEnum)123);
     }
 
 
@@ -441,18 +441,18 @@ public sealed class SameValueDiscontinuousTests
         foreach (var x in parameters)
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<SameValueDiscontinuousEnum>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<SameValueDiscontinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<SameValueDiscontinuousEnum>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<SameValueDiscontinuousEnum>("123", ignoreCase).Should().Be((SameValueDiscontinuousEnum)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<SameValueDiscontinuousEnum>("ABCDE", ignoreCase));
+        FastEnum.Parse<SameValueDiscontinuousEnum>("123", ignoreCase).ShouldBe((SameValueDiscontinuousEnum)123);
     }
 
 
@@ -471,27 +471,27 @@ public sealed class SameValueDiscontinuousTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SameValueDiscontinuousEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SameValueDiscontinuousEnum)123);
+        FastEnum.TryParse<SameValueDiscontinuousEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SameValueDiscontinuousEnum)123);
     }
 
 
@@ -510,30 +510,30 @@ public sealed class SameValueDiscontinuousTests
         {
             var valueString = ((byte)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<SameValueDiscontinuousEnum>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<SameValueDiscontinuousEnum>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<SameValueDiscontinuousEnum>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((SameValueDiscontinuousEnum)123);
+        FastEnum.TryParse<SameValueDiscontinuousEnum>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<SameValueDiscontinuousEnum>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((SameValueDiscontinuousEnum)123);
     }
 
 
@@ -547,11 +547,11 @@ public sealed class SameValueDiscontinuousTests
             var member = value.ToMember()!;
             var info = typeof(SameValueDiscontinuousEnum).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
         {
             var value = SameValueDiscontinuousEnum.B;
@@ -560,11 +560,11 @@ public sealed class SameValueDiscontinuousTests
             var member = value.ToMember()!;
             var info = typeof(SameValueDiscontinuousEnum).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
         {
             var value = SameValueDiscontinuousEnum.C;
@@ -573,11 +573,11 @@ public sealed class SameValueDiscontinuousTests
             var member = value.ToMember()!;
             var info = typeof(SameValueDiscontinuousEnum).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
         {
             var value = SameValueDiscontinuousEnum.D;
@@ -586,11 +586,11 @@ public sealed class SameValueDiscontinuousTests
             var member = value.ToMember()!;
             var info = typeof(SameValueDiscontinuousEnum).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
     }
 
@@ -603,7 +603,7 @@ public sealed class SameValueDiscontinuousTests
         {
             var expect = Enum.GetName(x);
             var actual = x.ToName();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 
@@ -616,7 +616,7 @@ public sealed class SameValueDiscontinuousTests
         {
             var expect = Enum.GetName(x);
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/SameValueTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/SameValueTests.tt
@@ -20,8 +20,8 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using FastEnumUtility.UnitTests.Models;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace FastEnumUtility.UnitTests.Cases.Reflections;
 
@@ -36,7 +36,7 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
     {
         var expect = Enum.GetValues<<#= x.EnumType #>>();
         var actual = FastEnum.GetValues<<#= x.EnumType #>>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -45,7 +45,7 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
     {
         var expect = Enum.GetNames(typeof(<#= x.EnumType #>));
         var actual = FastEnum.GetNames<<#= x.EnumType #>>();
-        actual.Should().BeEquivalentTo(expect);
+        actual.ShouldBe(expect);
     }
 
 
@@ -64,19 +64,19 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
             .ToArray();
         var actual = FastEnum.GetMembers<<#= x.EnumType #>>();
 
-        actual.Length.Should().Be(expect.Length);
+        actual.Length.ShouldBe(expect.Length);
         for (var i = 0; i < expect.Length; i++)
         {
             var a = actual[i];
             var e = expect[i];
-            a.Value.Should().Be(e.value);
-            a.Name.Should().Be(e.name);
-            a.NameUtf8.Should().Equal(e.nameUtf8);
-            a.FieldInfo.Should().Be(e.fieldInfo);
+            a.Value.ShouldBe(e.value);
+            a.Name.ShouldBe(e.name);
+            a.NameUtf8.ShouldBe(e.nameUtf8);
+            a.FieldInfo.ShouldBe(e.fieldInfo);
 
             var (name, value) = a;
-            value.Should().Be(e.value);
-            name.Should().Be(e.name);
+            value.ShouldBe(e.value);
+            name.ShouldBe(e.name);
         }
     }
 
@@ -85,25 +85,25 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
     public void IsDefined()
     {
         //--- IsDefined(TEnum)
-        FastEnum.IsDefined(<#= x.EnumType #>.A).Should().BeTrue();
-        FastEnum.IsDefined(<#= x.EnumType #>.B).Should().BeTrue();
-        FastEnum.IsDefined(<#= x.EnumType #>.C).Should().BeTrue();
-        FastEnum.IsDefined(<#= x.EnumType #>.D).Should().BeTrue();
-        FastEnum.IsDefined((<#= x.EnumType #>)123).Should().BeFalse();
+        FastEnum.IsDefined(<#= x.EnumType #>.A).ShouldBeTrue();
+        FastEnum.IsDefined(<#= x.EnumType #>.B).ShouldBeTrue();
+        FastEnum.IsDefined(<#= x.EnumType #>.C).ShouldBeTrue();
+        FastEnum.IsDefined(<#= x.EnumType #>.D).ShouldBeTrue();
+        FastEnum.IsDefined((<#= x.EnumType #>)123).ShouldBeFalse();
 
         //--- Extension methods
-        <#= x.EnumType #>.A.IsDefined().Should().BeTrue();
-        <#= x.EnumType #>.B.IsDefined().Should().BeTrue();
-        <#= x.EnumType #>.C.IsDefined().Should().BeTrue();
-        <#= x.EnumType #>.D.IsDefined().Should().BeTrue();
+        <#= x.EnumType #>.A.IsDefined().ShouldBeTrue();
+        <#= x.EnumType #>.B.IsDefined().ShouldBeTrue();
+        <#= x.EnumType #>.C.IsDefined().ShouldBeTrue();
+        <#= x.EnumType #>.D.IsDefined().ShouldBeTrue();
 
         //--- IsDefined(ReadOnlySpan<char>)
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.A)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.B)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.C)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.D)).Should().BeTrue();
-        FastEnum.IsDefined<<#= x.EnumType #>>("123").Should().BeFalse();
-        FastEnum.IsDefined<<#= x.EnumType #>>("value").Should().BeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.A)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.B)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.C)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>(nameof(<#= x.EnumType #>.D)).ShouldBeTrue();
+        FastEnum.IsDefined<<#= x.EnumType #>>("123").ShouldBeFalse();
+        FastEnum.IsDefined<<#= x.EnumType #>>("value").ShouldBeFalse();
     }
 
 
@@ -121,18 +121,18 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FluentActions.Invoking(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase)).Should().Throw<ArgumentException>();
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            Should.Throw<ArgumentException>(() => FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase));
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -150,18 +150,18 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         foreach (var x in parameters)
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
-            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).Should().Be(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString, ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
+            FastEnum.Parse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase).ShouldBe(x.value);
         }
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase)).Should().Throw<ArgumentException>();
-        FluentActions.Invoking(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase)).Should().Throw<ArgumentException>();
-        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).Should().Be((<#= x.EnumType #>)123);
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>((string?)null, ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>(" ", ignoreCase));
+        Should.Throw<ArgumentException>(static () => FastEnum.Parse<<#= x.EnumType #>>("ABCDE", ignoreCase));
+        FastEnum.Parse<<#= x.EnumType #>>("123", ignoreCase).ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -180,27 +180,27 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeFalse();
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).Should().BeTrue();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeFalse();
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var _).ShouldBeTrue();
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -219,30 +219,30 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         {
             var valueString = ((<#= x.UnderlyingType #>)x.value).ToString(CultureInfo.InvariantCulture);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).Should().BeTrue();
-            r1.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name, ignoreCase, out var r1).ShouldBeTrue();
+            r1.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).Should().BeTrue();
-            r2.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r2).ShouldBeTrue();
+            r2.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).Should().BeTrue();
-            r3.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(x.name.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r3).ShouldBeTrue();
+            r3.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r4).Should().BeTrue();
-            r4.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString, ignoreCase, out var r4).ShouldBeTrue();
+            r4.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).Should().BeTrue();
-            r5.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToLower(CultureInfo.InvariantCulture), ignoreCase, out var r5).ShouldBeTrue();
+            r5.ShouldBe(x.value);
 
-            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).Should().BeTrue();
-            r6.Should().Be(x.value);
+            FastEnum.TryParse<<#= x.EnumType #>>(valueString.ToUpper(CultureInfo.InvariantCulture), ignoreCase, out var r6).ShouldBeTrue();
+            r6.ShouldBe(x.value);
         }
-        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).Should().BeFalse();
-        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).Should().BeTrue();
-        r.Should().Be((<#= x.EnumType #>)123);
+        FastEnum.TryParse<<#= x.EnumType #>>((string?)null, ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>(" ", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("ABCDE", ignoreCase, out var _).ShouldBeFalse();
+        FastEnum.TryParse<<#= x.EnumType #>>("123", ignoreCase, out var r).ShouldBeTrue();
+        r.ShouldBe((<#= x.EnumType #>)123);
     }
 
 
@@ -256,11 +256,11 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
             var member = value.ToMember()!;
             var info = typeof(<#= x.EnumType #>).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
         {
             var value = <#= x.EnumType #>.B;
@@ -269,11 +269,11 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
             var member = value.ToMember()!;
             var info = typeof(<#= x.EnumType #>).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
         {
             var value = <#= x.EnumType #>.C;
@@ -282,11 +282,11 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
             var member = value.ToMember()!;
             var info = typeof(<#= x.EnumType #>).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
         {
             var value = <#= x.EnumType #>.D;
@@ -295,11 +295,11 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
             var member = value.ToMember()!;
             var info = typeof(<#= x.EnumType #>).GetField(name);
 
-            member.Should().NotBeNull();
-            member.Name.Should().Be(name);
-            member.NameUtf8.Should().Equal(nameUtf8);
-            member.Value.Should().Be(value);
-            member.FieldInfo.Should().Be(info);
+            member.ShouldNotBeNull();
+            member.Name.ShouldBe(name);
+            member.NameUtf8.ShouldBe(nameUtf8);
+            member.Value.ShouldBe(value);
+            member.FieldInfo.ShouldBe(info);
         }
     }
 
@@ -312,7 +312,7 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         {
             var expect = Enum.GetName(x);
             var actual = x.ToName();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 
@@ -325,7 +325,7 @@ public sealed class SameValue<#= x.IsContinuous ? "Continuous" : "Discontinuous"
         {
             var expect = Enum.GetName(x);
             var actual = x.FastToString();
-            actual.Should().Be(expect);
+            actual.ShouldBe(expect);
         }
     }
 }

--- a/src/insights/FastEnum.UnitTests/FastEnum.UnitTests.csproj
+++ b/src/insights/FastEnum.UnitTests/FastEnum.UnitTests.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="MSTest" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/insights/FastEnum.UnitTests/FastEnum.UnitTests.csproj
+++ b/src/insights/FastEnum.UnitTests/FastEnum.UnitTests.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="MSTest" />
         <PackageReference Include="Shouldly" />
     </ItemGroup>


### PR DESCRIPTION
# Summary
In response to the recent license modifications of [FluentAssertions](https://github.com/fluentassertions/fluentassertions) v8.x, I have made the decision to transition to [Shouldly](https://github.com/shouldly/shouldly).