### PR TITLE
Remove unnecessary pragma

### DIFF
--- a/src/libs/FastEnum.Generators/Internals/DiagnosticDescriptorProvider.cs
+++ b/src/libs/FastEnum.Generators/Internals/DiagnosticDescriptorProvider.cs
@@ -11,7 +11,6 @@ internal static class DiagnosticDescriptorProvider
     #endregion
 
 
-#pragma warning disable RS2008
     public static readonly DiagnosticDescriptor MustBePartial
         = new(
             id: "FE0001",
@@ -54,5 +53,4 @@ internal static class DiagnosticDescriptorProvider
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true
         );
-#pragma warning restore RS2008
 }


### PR DESCRIPTION
This pull request removes the `#pragma warning disable RS2008` and `#pragma warning restore RS2008` directives from the `DiagnosticDescriptorProvider` class. These pragmas were previously used to suppress a specific Roslyn analyzer warning about diagnostic descriptors.

Code cleanup:

* Removed `#pragma warning disable RS2008` and `#pragma warning restore RS2008` directives from `DiagnosticDescriptorProvider`, as they are no longer needed.