### PR TITLE
Specify commit hash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: 10.0.x
 
@@ -32,7 +32,7 @@ jobs:
         run: dotnet --version
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: ${{ env.CheckoutDirectory }}
           fetch-depth: 0


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use specific commit hashes for third-party actions, improving build security and reproducibility.