### PR TITLE
Refactor benchmark configuration

### DIFF
--- a/src/insights/FastEnum.Benchmarks/FastEnum.Benchmarks.csproj
+++ b/src/insights/FastEnum.Benchmarks/FastEnum.Benchmarks.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>net10.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <RootNamespace>FastEnumUtility.Benchmarks</RootNamespace>
     </PropertyGroup>

--- a/src/insights/FastEnum.Benchmarks/Internals/BenchmarkConfig.cs
+++ b/src/insights/FastEnum.Benchmarks/Internals/BenchmarkConfig.cs
@@ -10,24 +10,18 @@ namespace FastEnumUtility.Benchmarks.Internals;
 internal static class BenchmarkConfig
 {
     public static IConfig ForDefault()
-    {
-        return ManualConfig.CreateMinimumViable()
-            .AddExporter(MarkdownExporter.GitHub)
-            .AddDiagnoser(MemoryDiagnoser.Default)
-            .AddDiagnoser(new DisassemblyDiagnoser(new
-            (
-                maxDepth: 3,
-                printSource: true,
-                exportGithubMarkdown: true,
-                exportCombinedDisassemblyReport: true
-            )))
-            .AddJob(Job.Default);
-    }
+        => CreateSharedConfig(Job.Default);
 
 
     public static IConfig ForShortRun()
+        => CreateSharedConfig(Job.ShortRun);
+
+
+    #region Helpers
+    private static ManualConfig CreateSharedConfig(Job job)
     {
-        return ManualConfig.CreateMinimumViable()
+        return ManualConfig
+            .CreateMinimumViable()
             .AddExporter(MarkdownExporter.GitHub)
             .AddDiagnoser(MemoryDiagnoser.Default)
             .AddDiagnoser(new DisassemblyDiagnoser(new
@@ -37,6 +31,7 @@ internal static class BenchmarkConfig
                 exportGithubMarkdown: true,
                 exportCombinedDisassemblyReport: true
             )))
-            .AddJob(Job.ShortRun);
+            .AddJob(job);
     }
+    #endregion
 }

--- a/src/insights/FastEnum.Benchmarks/Internals/BenchmarkConfig.cs
+++ b/src/insights/FastEnum.Benchmarks/Internals/BenchmarkConfig.cs
@@ -14,6 +14,13 @@ internal static class BenchmarkConfig
         return ManualConfig.CreateMinimumViable()
             .AddExporter(MarkdownExporter.GitHub)
             .AddDiagnoser(MemoryDiagnoser.Default)
+            .AddDiagnoser(new DisassemblyDiagnoser(new
+            (
+                maxDepth: 3,
+                printSource: true,
+                exportGithubMarkdown: true,
+                exportCombinedDisassemblyReport: true
+            )))
             .AddJob(Job.Default);
     }
 
@@ -23,6 +30,13 @@ internal static class BenchmarkConfig
         return ManualConfig.CreateMinimumViable()
             .AddExporter(MarkdownExporter.GitHub)
             .AddDiagnoser(MemoryDiagnoser.Default)
+            .AddDiagnoser(new DisassemblyDiagnoser(new
+            (
+                maxDepth: 3,
+                printSource: true,
+                exportGithubMarkdown: true,
+                exportCombinedDisassemblyReport: true
+            )))
             .AddJob(Job.ShortRun);
     }
 }


### PR DESCRIPTION
This pull request updates the benchmarking configuration and project settings for the `FastEnum.Benchmarks` project. The main changes are the addition of .NET 10.0 as a target framework and improvements to the benchmark configuration logic, including enhanced diagnoser support.

**Project configuration updates:**
- Added .NET 10.0 as a target framework in the `FastEnum.Benchmarks` project file, enabling benchmarking on the latest .NET version.

**Benchmark configuration refactoring and enhancements:**
- Refactored the `BenchmarkConfig` class to use a shared helper method (`CreateSharedConfig`) for creating configurations, reducing code duplication between `ForDefault` and `ForShortRun` methods.
- Enhanced the benchmark diagnosers by adding a `DisassemblyDiagnoser` with detailed options (e.g., maxDepth, printSource, GitHub markdown export, combined report), providing deeper performance insights during benchmarking.