### PR TITLE
Improve `GetHashCode` performance

### DIFF
--- a/src/libs/FastEnum.Core/Internals/StringHelper.cs
+++ b/src/libs/FastEnum.Core/Internals/StringHelper.cs
@@ -42,16 +42,17 @@ internal static class StringHelper
             //  - Computes a hash in O(1) without scanning the whole string, using only the length, the first character, and the last character.
             //
             // Bit composition:
-            //  - (length << 16) ^ (first << 8) ^ last
-            //      - length        -> occupies bit16 and above
-            //      - first (16bit) -> occupies bit8-23
-            //      - last  (16bit) -> occupies bit0-15
+            //  - (length << 16) ^ (first << 8) ^ (middle << 4) ^ last
+            //      - length         -> occupies bit16 and above
+            //      - first  (16bit) -> occupies bit8-23
+            //      - middle (16bit) -> occupies bit4-19
+            //      - last   (16bit) -> occupies bit0-15
             //  - The bit 8-23 and bit 16-23 ranges intentionally overlap; XOR-ing them (instead of simple bit-packing) improves diffusion slightly.
-            //  - Note: when (length == 1), (first == last), but different shift amounts prevent the hash from degenerating to a constant.
+            //  - Note: when (length == 1), (first == middle == last), but different shift amounts prevent the hash from degenerating to a constant.
             //
             // Trade-off:
             //  + Constant-time cost regardless of string length.
-            //  - Strings with the same length/first/last but different middle content collide (e.g. "aXXXXc" vs "aYYYYc").
+            //  - Strings with the same length/first/middle/last but different middle content collide (e.g. "aXXbXXc" vs "aYYbYYc").
             //      => Intended to be used as a cheap pre-filter, always paired with a strict equality check (e.g. SequenceEqual) after a hash match.
             //
             // Determinism:
@@ -61,9 +62,13 @@ internal static class StringHelper
             if (length is 0)
                 return 0;
 
+            var first = value.At(0);
+            var middle = value.At(length >> 1);
+            var last = value.At(length - 1);
             return (length << 16)
-                ^ (value.At(0) << 8)
-                ^ value.At(length - 1);
+                ^ (first << 8)
+                ^ (middle << 4)
+                ^ last;
 
             /*
             // note:
@@ -90,11 +95,10 @@ internal static class StringHelper
         public static int GetHashCode(ReadOnlySpan<char> value)
         {
             // Difference from the base version:
-            //  - Structurally identical (same length guard, same bit composition), except the first and last characters are normalized via `char.ToUpperInvariant()` before being folded into the hash:
-            //  - (length << 16) ^ (ToUpperInvariant(first) << 8) ^ ToUpperInvariant(last)
+            //  - Structurally identical (same length guard, same bit composition), except the first/middle/last characters are normalized via `char.ToUpperInvariant()` before being folded into the hash.
             //
             // Purpose:
-            //  - Produces a case-insensitive hash. E.g. "Get", "GET", and "get" all hash to the same value, since their first/last characters normalize to the same uppercase form.
+            //  - Produces a case-insensitive hash. E.g. "Get", "GET", and "get" all hash to the same value, since their first/middle/last characters normalize to the same uppercase form.
             //
             // Why this is required, not optional:
             //  - A hash function must respect the same equivalence relation as its paired equality comparer (the hash contract: x == y implies hash(x) == hash(y)).
@@ -112,9 +116,13 @@ internal static class StringHelper
             if (length is 0)
                 return 0;
 
+            var first = value.At(0);
+            var middle = value.At(length >> 1);
+            var last = value.At(length - 1);
             return (length << 16)
-                ^ (char.ToUpperInvariant(value.At(0)) << 8)
-                ^ char.ToUpperInvariant(value.At(length - 1));
+                ^ (char.ToUpperInvariant(first) << 8)
+                ^ (char.ToUpperInvariant(middle) << 4)
+                ^ char.ToUpperInvariant(last);
 
             /*
             // note:

--- a/src/libs/FastEnum.Core/Internals/StringHelper.cs
+++ b/src/libs/FastEnum.Core/Internals/StringHelper.cs
@@ -107,7 +107,7 @@ internal static class StringHelper
             //
             // Why ToUpperInvariant (not ToUpper / ToLower):
             //  - `Invariant` avoids culture-dependent casing rules (e.g. Turkish i/İ), keeping the hash deterministic regardless of the runtime's locale.
-            //  - Using "upper" consistently (rather than mixing upper/lower) is what actually matters; the codebase settles on ToUpperInvariant throughout.
+            //  - Using "upper" consistently (rather than mixing upper/lower) is what actually matters; this implementation uses ToUpperInvariant for consistency.
             //
             // Cost:
             //  - Adds two O(1) char-normalization calls versus the base version; overall complexity remains O(1). Negligible price for case-insensitive semantics.

--- a/src/libs/FastEnum.Core/Internals/StringHelper.cs
+++ b/src/libs/FastEnum.Core/Internals/StringHelper.cs
@@ -38,6 +38,34 @@ internal static class StringHelper
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetHashCode(ReadOnlySpan<char> value)
         {
+            // Purpose:
+            //  - Computes a hash in O(1) without scanning the whole string, using only the length, the first character, and the last character.
+            //
+            // Bit composition:
+            //  - (length << 16) ^ (first << 8) ^ last
+            //      - length        -> occupies bit16 and above
+            //      - first (16bit) -> occupies bit8-23
+            //      - last  (16bit) -> occupies bit0-15
+            //  - The bit 8-23 and bit 16-23 ranges intentionally overlap; XOR-ing them (instead of simple bit-packing) improves diffusion slightly.
+            //  - Note: when (length == 1), (first == last), but different shift amounts prevent the hash from degenerating to a constant.
+            //
+            // Trade-off:
+            //  + Constant-time cost regardless of string length.
+            //  - Strings with the same length/first/last but different middle content collide (e.g. "aXXXXc" vs "aYYYYc").
+            //      => Intended to be used as a cheap pre-filter, always paired with a strict equality check (e.g. SequenceEqual) after a hash match.
+            //
+            // Determinism:
+            //  - Unlike the default `string.GetHashCode()`, which uses a per-process random seed, this hash depends only on the input and is fully deterministic / reproducible across processes.
+
+            var length = value.Length;
+            if (length is 0)
+                return 0;
+
+            return (length << 16)
+                ^ (value.At(0) << 8)
+                ^ value.At(length - 1);
+
+            /*
             // note:
             //  - Suppress CA1307 : Specify StringComparison for clarity
             //  - Overload that specify StringComparison is slow because of internal branching by switch statements.
@@ -45,6 +73,7 @@ internal static class StringHelper
 #pragma warning disable CA1307
             return string.GetHashCode(value);
 #pragma warning restore CA1307
+            */
         }
 
 
@@ -60,6 +89,34 @@ internal static class StringHelper
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetHashCode(ReadOnlySpan<char> value)
         {
+            // Difference from the base version:
+            //  - Structurally identical (same length guard, same bit composition), except the first and last characters are normalized via `char.ToUpperInvariant()` before being folded into the hash:
+            //  - (length << 16) ^ (ToUpperInvariant(first) << 8) ^ ToUpperInvariant(last)
+            //
+            // Purpose:
+            //  - Produces a case-insensitive hash. E.g. "Get", "GET", and "get" all hash to the same value, since their first/last characters normalize to the same uppercase form.
+            //
+            // Why this is required, not optional:
+            //  - A hash function must respect the same equivalence relation as its paired equality comparer (the hash contract: x == y implies hash(x) == hash(y)).
+            //  - This variant is meant to be paired with a case-insensitive equality check (e.g. OrdinalIgnoreCase, or enum Parse with ignoreCase: true).
+            //  - Without the uppercasing step, that contract would break - "GET" and "get" would be equal but could land in different hash buckets, which is a correctness bug, not just a performance issue.
+            //
+            // Why ToUpperInvariant (not ToUpper / ToLower):
+            //  - `Invariant` avoids culture-dependent casing rules (e.g. Turkish i/İ), keeping the hash deterministic regardless of the runtime's locale.
+            //  - Using "upper" consistently (rather than mixing upper/lower) is what actually matters; the codebase settles on ToUpperInvariant throughout.
+            //
+            // Cost:
+            //  - Adds two O(1) char-normalization calls versus the base version; overall complexity remains O(1). Negligible price for case-insensitive semantics.
+
+            var length = value.Length;
+            if (length is 0)
+                return 0;
+
+            return (length << 16)
+                ^ (char.ToUpperInvariant(value.At(0)) << 8)
+                ^ char.ToUpperInvariant(value.At(length - 1));
+
+            /*
             // note:
             //  - Overload that specify StringComparison is slow because of internal branching by switch statements.
 
@@ -72,6 +129,7 @@ internal static class StringHelper
             [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "GetHashCodeOrdinalIgnoreCase")]
             static extern int string_GetHashCodeOrdinalIgnoreCase(string? self, ReadOnlySpan<char> value);
             #endregion
+            */
         }
 
 

--- a/src/libs/FastEnum.Core/Internals/StringHelper.cs
+++ b/src/libs/FastEnum.Core/Internals/StringHelper.cs
@@ -43,7 +43,7 @@ internal static class StringHelper
             //
             // Bit composition:
             //  - (length << 16) ^ (first << 8) ^ (middle << 4) ^ last
-            //      - length         -> occupies bit16 and above
+            //      - length         -> occupies bit16-31
             //      - first  (16bit) -> occupies bit8-23
             //      - middle (16bit) -> occupies bit4-19
             //      - last   (16bit) -> occupies bit0-15


### PR DESCRIPTION
# Summary
A lightweight hash function for `ReadOnlySpan<char>` that computes a hash in **O(1) without scanning the whole string**. It relies on only three pieces of information:

- `length` (the string length)
- the first character, `value[0]`
- the last character, `value[length - 1]`


# Benchmark result
Approximately **x1.6 faster**.

```md
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8737/25H2/2025Update/HudsonValley2)
Intel Core Ultra 7 155H 3.00GHz, 1 CPU, 22 logical and 16 physical cores
.NET SDK 10.0.301
  [Host]     : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3


| Method             | Mean       | Error    | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------- |-----------:|---------:|----------:|------:|--------:|----------:|------------:|
| String_GetHashCode | 1,518.8 ns | 29.61 ns |  45.22 ns |  1.00 |    0.04 |         - |          NA |
| Custom_GetHashCode |   947.9 ns | 37.25 ns | 109.83 ns |  0.62 |    0.07 |         - |          NA |
```


# Details
## 1. Empty-string guard

```cs
var length = value.Length;
if (length is 0)
    return 0;
```

If `length == 0`, accessing `value[0]` or `value[length - 1]` (i.e. `value[-1]`) would be out of bounds. Since `At()` uses `Unsafe.Add` and performs **no bounds checking**, calling it on an empty span would be undefined behavior (an out-of-bounds memory read). This isn't just a semantic special case — **it's a required guard for the safety of the subsequent `At()` calls**.


## 2. Bit composition of the hash
```cs
return (length << 16)
    ^ (value.At(0) << 8)
    ^ (value.At(length >> 1) << 4)
    ^ value.At(length - 1);
```

`char` is implicitly widened to `int` as a zero-extended 16-bit value. The bit ranges occupied by each term are:

| Term | Type / range | Bits occupied after shift |
|---|---|---|
| `length << 16` | `int` (only low bits are meaningful in practice) | bits 16–31 |
| `value.At(0) << 8` (first char) | 0–65535 → 16 bits | bits 8–23 |
| `value.At(length >> 1) << 4` (middle char) | 0–65535 → 16 bits | bits 4–19 |
| `value.At(length - 1)` (last char) | 0–65535 → 16 bits | bits 0–15 |

The ranges **intentionally overlap**. Rather than simply packing the values into disjoint bit fields, XOR-ing them with a shift offset lets each input (length, first char, last char) affect a wider range of bits, giving a small improvement in diffusion (avalanche behavior).


## 3. Design trade-off: speed vs. collision resistance
- **Pro:** Constant-time cost (O(1)) regardless of string length — significantly faster than a full scan such as the default `string.GetHashCode()`.
- **Con:** Strings with the same length, first character, middle character and last character will collide even if their contents differ entirely in between.
    - Example: `"aXXbXXc"` and `"aYYbYYc"` (same length/first/middle/last) collide.

Because of this, the function is **not suited for large hash tables or scenarios with adversarial input (e.g. hash-flooding DoS)**. It's intended for use cases like lightweight cache keys over short strings, or as a cheap pre-filter that is always followed by a strict equality check (e.g. `SequenceEqual`) on collision. It is suitable for use with `enum` fields.


## 4. Note on determinism
Since .NET Core, the default `string.GetHashCode()` uses a per-process randomized seed, so its output varies across process runs. This custom `GetHashCode()`, by contrast, is **fully deterministic** — it depends only on the input. That determinism can be a deliberate advantage for use cases involving persisted hash values or requiring consistency across processes.