### PR TITLE
Improve `.ToNumberString()` performance

### DIFF
--- a/src/insights/FastEnum.UnitTests/Cases/Generators/BasicTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Generators/BasicTests.cs
@@ -196,8 +196,12 @@ public sealed class BasicSByteTests
     [TestMethod]
     public void FastToString()
     {
-        const SByteEnum undefined = (SByteEnum)123;
-        var values = Enum.GetValues<SByteEnum>().Append(undefined);
+        const SByteEnum undefined1 = (SByteEnum)123;
+        const SByteEnum undefined2 = (SByteEnum)(-123);
+        var values
+            = Enum.GetValues<SByteEnum>()
+            .Append(undefined1)
+            .Append(undefined2);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -384,8 +388,8 @@ public sealed class BasicByteTests
     [TestMethod]
     public void FastToString()
     {
-        const ByteEnum undefined = (ByteEnum)123;
-        var values = Enum.GetValues<ByteEnum>().Append(undefined);
+        const ByteEnum undefined1 = (ByteEnum)123;
+        var values = Enum.GetValues<ByteEnum>().Append(undefined1);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -578,8 +582,12 @@ public sealed class BasicInt16Tests
     [TestMethod]
     public void FastToString()
     {
-        const Int16Enum undefined = (Int16Enum)123;
-        var values = Enum.GetValues<Int16Enum>().Append(undefined);
+        const Int16Enum undefined1 = (Int16Enum)123;
+        const Int16Enum undefined2 = (Int16Enum)(-123);
+        var values
+            = Enum.GetValues<Int16Enum>()
+            .Append(undefined1)
+            .Append(undefined2);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -766,8 +774,8 @@ public sealed class BasicUInt16Tests
     [TestMethod]
     public void FastToString()
     {
-        const UInt16Enum undefined = (UInt16Enum)123;
-        var values = Enum.GetValues<UInt16Enum>().Append(undefined);
+        const UInt16Enum undefined1 = (UInt16Enum)123;
+        var values = Enum.GetValues<UInt16Enum>().Append(undefined1);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -960,8 +968,12 @@ public sealed class BasicInt32Tests
     [TestMethod]
     public void FastToString()
     {
-        const Int32Enum undefined = (Int32Enum)123;
-        var values = Enum.GetValues<Int32Enum>().Append(undefined);
+        const Int32Enum undefined1 = (Int32Enum)123;
+        const Int32Enum undefined2 = (Int32Enum)(-123);
+        var values
+            = Enum.GetValues<Int32Enum>()
+            .Append(undefined1)
+            .Append(undefined2);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -1148,8 +1160,8 @@ public sealed class BasicUInt32Tests
     [TestMethod]
     public void FastToString()
     {
-        const UInt32Enum undefined = (UInt32Enum)123;
-        var values = Enum.GetValues<UInt32Enum>().Append(undefined);
+        const UInt32Enum undefined1 = (UInt32Enum)123;
+        var values = Enum.GetValues<UInt32Enum>().Append(undefined1);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -1342,8 +1354,12 @@ public sealed class BasicInt64Tests
     [TestMethod]
     public void FastToString()
     {
-        const Int64Enum undefined = (Int64Enum)123;
-        var values = Enum.GetValues<Int64Enum>().Append(undefined);
+        const Int64Enum undefined1 = (Int64Enum)123;
+        const Int64Enum undefined2 = (Int64Enum)(-123);
+        var values
+            = Enum.GetValues<Int64Enum>()
+            .Append(undefined1)
+            .Append(undefined2);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -1530,8 +1546,8 @@ public sealed class BasicUInt64Tests
     [TestMethod]
     public void FastToString()
     {
-        const UInt64Enum undefined = (UInt64Enum)123;
-        var values = Enum.GetValues<UInt64Enum>().Append(undefined);
+        const UInt64Enum undefined1 = (UInt64Enum)123;
+        var values = Enum.GetValues<UInt64Enum>().Append(undefined1);
         foreach (var x in values)
         {
             var expect = x.ToString();

--- a/src/insights/FastEnum.UnitTests/Cases/Generators/BasicTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/Generators/BasicTests.tt
@@ -227,8 +227,16 @@ public sealed class Basic<#= x.AliasType #>Tests
     [TestMethod]
     public void FastToString()
     {
-        const <#= x.EnumType #> undefined = (<#= x.EnumType #>)123;
-        var values = Enum.GetValues<<#= x.EnumType #>>().Append(undefined);
+        const <#= x.EnumType #> undefined1 = (<#= x.EnumType #>)123;
+<# if (x.IsSignedType) { #>
+        const <#= x.EnumType #> undefined2 = (<#= x.EnumType #>)(-123);
+        var values
+            = Enum.GetValues<<#= x.EnumType #>>()
+            .Append(undefined1)
+            .Append(undefined2);
+<# } else { #>
+        var values = Enum.GetValues<<#= x.EnumType #>>().Append(undefined1);
+<# } #>
         foreach (var x in values)
         {
             var expect = x.ToString();

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/BasicTests.cs
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/BasicTests.cs
@@ -372,8 +372,12 @@ public sealed class BasicSByteTests
     [TestMethod]
     public void FastToString()
     {
-        const SByteEnum undefined = (SByteEnum)123;
-        var values = Enum.GetValues<SByteEnum>().Append(undefined);
+        const SByteEnum undefined1 = (SByteEnum)123;
+        const SByteEnum undefined2 = (SByteEnum)(-123);
+        var values
+            = Enum.GetValues<SByteEnum>()
+            .Append(undefined1)
+            .Append(undefined2);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -733,8 +737,8 @@ public sealed class BasicByteTests
     [TestMethod]
     public void FastToString()
     {
-        const ByteEnum undefined = (ByteEnum)123;
-        var values = Enum.GetValues<ByteEnum>().Append(undefined);
+        const ByteEnum undefined1 = (ByteEnum)123;
+        var values = Enum.GetValues<ByteEnum>().Append(undefined1);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -1102,8 +1106,12 @@ public sealed class BasicInt16Tests
     [TestMethod]
     public void FastToString()
     {
-        const Int16Enum undefined = (Int16Enum)123;
-        var values = Enum.GetValues<Int16Enum>().Append(undefined);
+        const Int16Enum undefined1 = (Int16Enum)123;
+        const Int16Enum undefined2 = (Int16Enum)(-123);
+        var values
+            = Enum.GetValues<Int16Enum>()
+            .Append(undefined1)
+            .Append(undefined2);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -1463,8 +1471,8 @@ public sealed class BasicUInt16Tests
     [TestMethod]
     public void FastToString()
     {
-        const UInt16Enum undefined = (UInt16Enum)123;
-        var values = Enum.GetValues<UInt16Enum>().Append(undefined);
+        const UInt16Enum undefined1 = (UInt16Enum)123;
+        var values = Enum.GetValues<UInt16Enum>().Append(undefined1);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -1832,8 +1840,12 @@ public sealed class BasicInt32Tests
     [TestMethod]
     public void FastToString()
     {
-        const Int32Enum undefined = (Int32Enum)123;
-        var values = Enum.GetValues<Int32Enum>().Append(undefined);
+        const Int32Enum undefined1 = (Int32Enum)123;
+        const Int32Enum undefined2 = (Int32Enum)(-123);
+        var values
+            = Enum.GetValues<Int32Enum>()
+            .Append(undefined1)
+            .Append(undefined2);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -2193,8 +2205,8 @@ public sealed class BasicUInt32Tests
     [TestMethod]
     public void FastToString()
     {
-        const UInt32Enum undefined = (UInt32Enum)123;
-        var values = Enum.GetValues<UInt32Enum>().Append(undefined);
+        const UInt32Enum undefined1 = (UInt32Enum)123;
+        var values = Enum.GetValues<UInt32Enum>().Append(undefined1);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -2562,8 +2574,12 @@ public sealed class BasicInt64Tests
     [TestMethod]
     public void FastToString()
     {
-        const Int64Enum undefined = (Int64Enum)123;
-        var values = Enum.GetValues<Int64Enum>().Append(undefined);
+        const Int64Enum undefined1 = (Int64Enum)123;
+        const Int64Enum undefined2 = (Int64Enum)(-123);
+        var values
+            = Enum.GetValues<Int64Enum>()
+            .Append(undefined1)
+            .Append(undefined2);
         foreach (var x in values)
         {
             var expect = x.ToString();
@@ -2923,8 +2939,8 @@ public sealed class BasicUInt64Tests
     [TestMethod]
     public void FastToString()
     {
-        const UInt64Enum undefined = (UInt64Enum)123;
-        var values = Enum.GetValues<UInt64Enum>().Append(undefined);
+        const UInt64Enum undefined1 = (UInt64Enum)123;
+        var values = Enum.GetValues<UInt64Enum>().Append(undefined1);
         foreach (var x in values)
         {
             var expect = x.ToString();

--- a/src/insights/FastEnum.UnitTests/Cases/Reflections/BasicTests.tt
+++ b/src/insights/FastEnum.UnitTests/Cases/Reflections/BasicTests.tt
@@ -406,8 +406,16 @@ public sealed class Basic<#= x.AliasType #>Tests
     [TestMethod]
     public void FastToString()
     {
-        const <#= x.EnumType #> undefined = (<#= x.EnumType #>)123;
-        var values = Enum.GetValues<<#= x.EnumType #>>().Append(undefined);
+        const <#= x.EnumType #> undefined1 = (<#= x.EnumType #>)123;
+<# if (x.IsSignedType) { #>
+        const <#= x.EnumType #> undefined2 = (<#= x.EnumType #>)(-123);
+        var values
+            = Enum.GetValues<<#= x.EnumType #>>()
+            .Append(undefined1)
+            .Append(undefined2);
+<# } else { #>
+        var values = Enum.GetValues<<#= x.EnumType #>>().Append(undefined1);
+<# } #>
         foreach (var x in values)
         {
             var expect = x.ToString();

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
@@ -166,10 +166,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                    var upper = (byte)(max - min);
-                    var lower = (byte)(val - min);
+                var upper = (byte)(max - min);
+                var lower = (byte)(val - min);
                     return lower <= upper;
-                }
+            }
             }
             else
             {
@@ -191,8 +191,14 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
+            // note:
+            //  - ToString() without IFormatProvider is faster because it goes straight to the digit-formatting fast path and returns cached strings for small values.
+            //  - Integer formatting depends on the culture only for the negative sign, which is the same behavior as System.Enum.ToString().
+
             var x = Unsafe.BitCast<T, sbyte>(value);
-            return x.ToString(null, CultureInfo.InvariantCulture);
+#pragma warning disable CA1305
+            return x.ToString();
+#pragma warning restore CA1305
         }
 
 
@@ -264,10 +270,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                    var upper = (byte)(max - min);
-                    var lower = (byte)(val - min);
+                var upper = (byte)(max - min);
+                var lower = (byte)(val - min);
                     return lower <= upper;
-                }
+            }
             }
             else
             {
@@ -289,8 +295,14 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
+            // note:
+            //  - ToString() without IFormatProvider is faster because it goes straight to the digit-formatting fast path and returns cached strings for small values.
+            //  - Integer formatting depends on the culture only for the negative sign, which is the same behavior as System.Enum.ToString().
+
             var x = Unsafe.BitCast<T, byte>(value);
-            return x.ToString(null, CultureInfo.InvariantCulture);
+#pragma warning disable CA1305
+            return x.ToString();
+#pragma warning restore CA1305
         }
 
 
@@ -362,10 +374,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                    var upper = (ushort)(max - min);
-                    var lower = (ushort)(val - min);
+                var upper = (ushort)(max - min);
+                var lower = (ushort)(val - min);
                     return lower <= upper;
-                }
+            }
             }
             else
             {
@@ -387,8 +399,14 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
+            // note:
+            //  - ToString() without IFormatProvider is faster because it goes straight to the digit-formatting fast path and returns cached strings for small values.
+            //  - Integer formatting depends on the culture only for the negative sign, which is the same behavior as System.Enum.ToString().
+
             var x = Unsafe.BitCast<T, short>(value);
-            return x.ToString(null, CultureInfo.InvariantCulture);
+#pragma warning disable CA1305
+            return x.ToString();
+#pragma warning restore CA1305
         }
 
 
@@ -460,10 +478,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                    var upper = (ushort)(max - min);
-                    var lower = (ushort)(val - min);
+                var upper = (ushort)(max - min);
+                var lower = (ushort)(val - min);
                     return lower <= upper;
-                }
+            }
             }
             else
             {
@@ -485,8 +503,14 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
+            // note:
+            //  - ToString() without IFormatProvider is faster because it goes straight to the digit-formatting fast path and returns cached strings for small values.
+            //  - Integer formatting depends on the culture only for the negative sign, which is the same behavior as System.Enum.ToString().
+
             var x = Unsafe.BitCast<T, ushort>(value);
-            return x.ToString(null, CultureInfo.InvariantCulture);
+#pragma warning disable CA1305
+            return x.ToString();
+#pragma warning restore CA1305
         }
 
 
@@ -558,10 +582,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                    var upper = (uint)(max - min);
-                    var lower = (uint)(val - min);
+                var upper = (uint)(max - min);
+                var lower = (uint)(val - min);
                     return lower <= upper;
-                }
+            }
             }
             else
             {
@@ -583,8 +607,14 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
+            // note:
+            //  - ToString() without IFormatProvider is faster because it goes straight to the digit-formatting fast path and returns cached strings for small values.
+            //  - Integer formatting depends on the culture only for the negative sign, which is the same behavior as System.Enum.ToString().
+
             var x = Unsafe.BitCast<T, int>(value);
-            return x.ToString(null, CultureInfo.InvariantCulture);
+#pragma warning disable CA1305
+            return x.ToString();
+#pragma warning restore CA1305
         }
 
 
@@ -656,10 +686,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                    var upper = (uint)(max - min);
-                    var lower = (uint)(val - min);
+                var upper = (uint)(max - min);
+                var lower = (uint)(val - min);
                     return lower <= upper;
-                }
+            }
             }
             else
             {
@@ -681,8 +711,14 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
+            // note:
+            //  - ToString() without IFormatProvider is faster because it goes straight to the digit-formatting fast path and returns cached strings for small values.
+            //  - Integer formatting depends on the culture only for the negative sign, which is the same behavior as System.Enum.ToString().
+
             var x = Unsafe.BitCast<T, uint>(value);
-            return x.ToString(null, CultureInfo.InvariantCulture);
+#pragma warning disable CA1305
+            return x.ToString();
+#pragma warning restore CA1305
         }
 
 
@@ -754,10 +790,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                    var upper = (ulong)(max - min);
-                    var lower = (ulong)(val - min);
+                var upper = (ulong)(max - min);
+                var lower = (ulong)(val - min);
                     return lower <= upper;
-                }
+            }
             }
             else
             {
@@ -779,8 +815,14 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
+            // note:
+            //  - ToString() without IFormatProvider is faster because it goes straight to the digit-formatting fast path and returns cached strings for small values.
+            //  - Integer formatting depends on the culture only for the negative sign, which is the same behavior as System.Enum.ToString().
+
             var x = Unsafe.BitCast<T, long>(value);
-            return x.ToString(null, CultureInfo.InvariantCulture);
+#pragma warning disable CA1305
+            return x.ToString();
+#pragma warning restore CA1305
         }
 
 
@@ -852,10 +894,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                    var upper = (ulong)(max - min);
-                    var lower = (ulong)(val - min);
+                var upper = (ulong)(max - min);
+                var lower = (ulong)(val - min);
                     return lower <= upper;
-                }
+            }
             }
             else
             {
@@ -877,8 +919,14 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
+            // note:
+            //  - ToString() without IFormatProvider is faster because it goes straight to the digit-formatting fast path and returns cached strings for small values.
+            //  - Integer formatting depends on the culture only for the negative sign, which is the same behavior as System.Enum.ToString().
+
             var x = Unsafe.BitCast<T, ulong>(value);
-            return x.ToString(null, CultureInfo.InvariantCulture);
+#pragma warning disable CA1305
+            return x.ToString();
+#pragma warning restore CA1305
         }
 
 

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.cs
@@ -166,10 +166,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                var upper = (byte)(max - min);
-                var lower = (byte)(val - min);
+                    var upper = (byte)(max - min);
+                    var lower = (byte)(val - min);
                     return lower <= upper;
-            }
+                }
             }
             else
             {
@@ -270,10 +270,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                var upper = (byte)(max - min);
-                var lower = (byte)(val - min);
+                    var upper = (byte)(max - min);
+                    var lower = (byte)(val - min);
                     return lower <= upper;
-            }
+                }
             }
             else
             {
@@ -374,10 +374,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                var upper = (ushort)(max - min);
-                var lower = (ushort)(val - min);
+                    var upper = (ushort)(max - min);
+                    var lower = (ushort)(val - min);
                     return lower <= upper;
-            }
+                }
             }
             else
             {
@@ -478,10 +478,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                var upper = (ushort)(max - min);
-                var lower = (ushort)(val - min);
+                    var upper = (ushort)(max - min);
+                    var lower = (ushort)(val - min);
                     return lower <= upper;
-            }
+                }
             }
             else
             {
@@ -582,10 +582,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                var upper = (uint)(max - min);
-                var lower = (uint)(val - min);
+                    var upper = (uint)(max - min);
+                    var lower = (uint)(val - min);
                     return lower <= upper;
-            }
+                }
             }
             else
             {
@@ -686,10 +686,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                var upper = (uint)(max - min);
-                var lower = (uint)(val - min);
+                    var upper = (uint)(max - min);
+                    var lower = (uint)(val - min);
                     return lower <= upper;
-            }
+                }
             }
             else
             {
@@ -790,10 +790,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                var upper = (ulong)(max - min);
-                var lower = (ulong)(val - min);
+                    var upper = (ulong)(max - min);
+                    var lower = (ulong)(val - min);
                     return lower <= upper;
-            }
+                }
             }
             else
             {
@@ -894,10 +894,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                var upper = (ulong)(max - min);
-                var lower = (ulong)(val - min);
+                    var upper = (ulong)(max - min);
+                    var lower = (ulong)(val - min);
                     return lower <= upper;
-            }
+                }
             }
             else
             {

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
@@ -132,10 +132,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                    var upper = (<#= x.RangeCheckName #>)(max - min);
-                    var lower = (<#= x.RangeCheckName #>)(val - min);
+                var upper = (<#= x.RangeCheckName #>)(max - min);
+                var lower = (<#= x.RangeCheckName #>)(val - min);
                     return lower <= upper;
-                }
+            }
             }
             else
             {
@@ -157,8 +157,14 @@ internal static class UnderlyingOperation<T>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ToNumberString(T value)
         {
+            // note:
+            //  - ToString() without IFormatProvider is faster because it goes straight to the digit-formatting fast path and returns cached strings for small values.
+            //  - Integer formatting depends on the culture only for the negative sign, which is the same behavior as System.Enum.ToString().
+
             var x = Unsafe.BitCast<T, <#= x.CompatibleName #>>(value);
-            return x.ToString(null, CultureInfo.InvariantCulture);
+#pragma warning disable CA1305
+            return x.ToString();
+#pragma warning restore CA1305
         }
 
 

--- a/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
+++ b/src/libs/FastEnum.Core/Internals/UnderlyingOperation.tt
@@ -132,10 +132,10 @@ internal static class UnderlyingOperation<T>
                 var val = toNumber(value);
                 unchecked
                 {
-                var upper = (<#= x.RangeCheckName #>)(max - min);
-                var lower = (<#= x.RangeCheckName #>)(val - min);
+                    var upper = (<#= x.RangeCheckName #>)(max - min);
+                    var lower = (<#= x.RangeCheckName #>)(val - min);
                     return lower <= upper;
-            }
+                }
             }
             else
             {


### PR DESCRIPTION
# Summary
**Change**: `x.ToString(null, CultureInfo.InvariantCulture)` → `x.ToString()`

Disassembly confirms the improvement: the previous code stopped short of inlining, making a non-inlined call to `UInt32ToDecStr`. With this change, inlining extends all the way to the load of the runtime's small-decimal string cache, turning a previously losing benchmark scenario into the fastest one.

The only behavioral change is that the sign of negative values becomes culture-dependent. This matches the existing behavior of `Enum.ToString()` in the BCL, and is consistent with the existing test assertion `FastToString() == ToString()`.


# Benchmark results
Approximately **x1.55 faster**.

```md
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8737/25H2/2025Update/HudsonValley2)
Intel Core Ultra 7 155H 3.00GHz, 1 CPU, 22 logical and 16 physical cores
.NET SDK 10.0.301
  [Host]     : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3


| Method   | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|--------- |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| WithArgs | 364.4 ns | 13.09 ns | 37.56 ns |  1.01 |    0.15 | 0.1349 |   1.66 KB |        1.00 |
| NoArgs   | 235.2 ns |  4.10 ns |  8.74 ns |  0.65 |    0.07 | 0.1349 |   1.66 KB |        1.00 |
```