### PR TITLE
Improve `.IsDefined(ReadOnlySpan<char>)` performance

### DIFF
--- a/src/libs/FastEnum.Generators/FastEnumBoosterGenerator.cs
+++ b/src/libs/FastEnum.Generators/FastEnumBoosterGenerator.cs
@@ -193,17 +193,16 @@ public sealed class FastEnumBoosterGenerator : IIncrementalGenerator
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     static bool IFastEnumBooster<{{param.EnumType.TypeName}}>.IsDefined(ReadOnlySpan<char> name)
                     {
+                        return name switch
+                        {
                 """);
             foreach (var field in param.EnumType.Fields)
             {
-                sb.AppendLine($$"""
-                            if (name.Equals(nameof({{param.EnumType.TypeName}}.{{field.Name}}), StringComparison.Ordinal))
-                                return true;
-
-                    """);
+                sb.AppendLine($"            nameof({param.EnumType.TypeName}.{field.Name}) => true,");
             }
-            sb.AppendLine($$"""
-                        return false;
+            sb.AppendLine("""
+                            _ => false,
+                        };
                     }
                 """);
         }


### PR DESCRIPTION
# Summary
A switch over the `ReadOnlySpan<char>` (≒ `string`) lets the compiler emit length + character dispatch instead of a linear chain of comparisons. Instead of using a chain of `if` statements, leverage the compiler's automatic optimization of `switch` statements to benefit from increased speed.

Fixes an issue where `IsDefined(ReadOnlySpan<char>)` failed to utilize the optimization via `switch` that was implemented in other methods.

# Benchmark results
Approximately **x5.88 faster**.

```md
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8737/25H2/2025Update/HudsonValley2)
Intel Core Ultra 7 155H 3.00GHz, 1 CPU, 22 logical and 16 physical cores
.NET SDK 10.0.301
  [Host]     : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3


| Method           | Mean       | Error    | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
|----------------- |-----------:|---------:|---------:|------:|--------:|----------:|------------:|
| IfStatement      | 1,044.8 ns | 13.89 ns | 35.36 ns |  1.00 |    0.04 |         - |          NA |
| SwitchExpression |   174.4 ns | 15.13 ns | 44.61 ns |  0.17 |    0.04 |         - |          NA |
```