### PR TITLE
Improve `.TryParseName()` performance

### DIFF
--- a/src/libs/FastEnum.Generators/FastEnumBoosterGenerator.cs
+++ b/src/libs/FastEnum.Generators/FastEnumBoosterGenerator.cs
@@ -247,18 +247,36 @@ public sealed class FastEnumBoosterGenerator : IIncrementalGenerator
                         [MethodImpl(MethodImplOptions.AggressiveInlining)]
                         static bool caseInsensitive(ReadOnlySpan<char> text, out {{param.EnumType.TypeName}} result)
                         {
+                            switch (text.Length)
+                            {
                 """);
-            foreach (var field in param.EnumType.Fields)
+            var byNameLength
+                = param.EnumType.Fields
+                .GroupBy(static x => x.Name.Length)
+                .OrderBy(static x => x.Key);
+            foreach (var group in byNameLength)
             {
-                sb.AppendLine($$"""
-                                if (text.Equals(nameof({{param.EnumType.TypeName}}.{{field.Name}}), StringComparison.OrdinalIgnoreCase))
-                                {
-                                    result = {{param.EnumType.TypeName}}.{{field.Name}};
-                                    return true;
-                                }
+                sb.AppendLine($"                case {group.Key}:");
+                foreach (var field in group)
+                {
+                    sb.AppendLine($$"""
+                                            if (text.Equals(nameof({{param.EnumType.TypeName}}.{{field.Name}}), StringComparison.OrdinalIgnoreCase))
+                                            {
+                                                result = {{param.EnumType.TypeName}}.{{field.Name}};
+                                                return true;
+                                            }
+                        """);
+                }
+                sb.AppendLine("""
+                                        break;
+
                     """);
             }
-            sb.AppendLine($$"""
+            sb.AppendLine("""
+                                default:
+                                    break;
+                            }
+
                             result = default;
                             return false;
                         }


### PR DESCRIPTION
# Summary
This pull request adjusts the logic to branch based on string length before performing detailed checks. Filtering by string length is extremely fast, as it does not require scanning the entire string. This significantly reduces the search overhead, which previously had a worst-case complexity of O(n). This approach mirrors the optimization of `switch` statements by the C# compiler.

# Benchmark results
Approximately **x4.25 faster**.

```md
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8737/25H2/2025Update/HudsonValley2)
Intel Core Ultra 7 155H 3.00GHz, 1 CPU, 22 logical and 16 physical cores
.NET SDK 10.0.301
  [Host]     : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3


| Method           | Mean       | Error    | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|----------------- |-----------:|---------:|----------:|------:|--------:|----------:|------------:|
| OnlyIfStatement  | 1,281.8 ns | 68.91 ns | 196.60 ns |  1.02 |    0.23 |         - |          NA |
| TextLengthSwitch |   296.3 ns | 14.97 ns |  44.14 ns |  0.24 |    0.05 |         - |          NA |
```