### PR TITLE
Add reflection benchmark

### DIFF
--- a/src/insights/FastEnum.Benchmarks/Scenarios/GetName.cs
+++ b/src/insights/FastEnum.Benchmarks/Scenarios/GetName.cs
@@ -2,7 +2,6 @@
 using BenchmarkDotNet.Attributes;
 using EnumsNET;
 using FastEnumUtility.Benchmarks.Models;
-using _FastEnum = FastEnumUtility.FastEnum;
 
 namespace FastEnumUtility.Benchmarks.Scenarios;
 
@@ -18,7 +17,7 @@ public class GetName
     {
         _ = Enum.GetNames<Fruits>();
         _ = Enums.GetNames<Fruits>();
-        _ = _FastEnum.GetNames<Fruits>();
+        _ = FastEnum.GetNames<Fruits>();
     }
 
 
@@ -33,6 +32,11 @@ public class GetName
 
 
     [Benchmark]
-    public string? FastEnum()
-        => _FastEnum.GetName<Fruits, FruitsBooster>(Value);
+    public string? FastEnum_Reflection()
+        => FastEnum.GetName(Value);
+
+
+    [Benchmark]
+    public string? FastEnum_SourceGen()
+        => FastEnum.GetName<Fruits, FruitsBooster>(Value);
 }

--- a/src/insights/FastEnum.Benchmarks/Scenarios/IsDefined_Enum.cs
+++ b/src/insights/FastEnum.Benchmarks/Scenarios/IsDefined_Enum.cs
@@ -2,7 +2,6 @@
 using BenchmarkDotNet.Attributes;
 using EnumsNET;
 using FastEnumUtility.Benchmarks.Models;
-using _FastEnum = FastEnumUtility.FastEnum;
 
 namespace FastEnumUtility.Benchmarks.Scenarios;
 
@@ -18,7 +17,7 @@ public class IsDefined_Enum
     {
         _ = Enum.GetNames<Fruits>();
         _ = Enums.GetMembers<Fruits>();
-        _ = _FastEnum.GetMembers<Fruits>();
+        _ = FastEnum.GetMembers<Fruits>();
     }
 
 
@@ -38,6 +37,11 @@ public class IsDefined_Enum
 
 
     [Benchmark]
-    public bool FastEnum()
-        => _FastEnum.IsDefined<Fruits, FruitsBooster>(Value);
+    public bool FastEnum_Reflection()
+        => FastEnum.IsDefined(Value);
+
+
+    [Benchmark]
+    public bool FastEnum_SourceGen()
+        => FastEnum.IsDefined<Fruits, FruitsBooster>(Value);
 }

--- a/src/insights/FastEnum.Benchmarks/Scenarios/IsDefined_String.cs
+++ b/src/insights/FastEnum.Benchmarks/Scenarios/IsDefined_String.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using BenchmarkDotNet.Attributes;
 using FastEnumUtility.Benchmarks.Models;
-using _FastEnum = FastEnumUtility.FastEnum;
 
 namespace FastEnumUtility.Benchmarks.Scenarios;
 
@@ -16,7 +15,7 @@ public class IsDefined_String
     public void Setup()
     {
         _ = Enum.GetNames<Fruits>();
-        _ = _FastEnum.GetMembers<Fruits>();
+        _ = FastEnum.GetMembers<Fruits>();
     }
 
 
@@ -31,6 +30,11 @@ public class IsDefined_String
 
 
     [Benchmark]
-    public bool FastEnum()
-        => _FastEnum.IsDefined<Fruits, FruitsBooster>(Value);
+    public bool FastEnum_Reflection()
+        => FastEnum.IsDefined<Fruits>(Value);
+
+
+    [Benchmark]
+    public bool FastEnum_SourceGen()
+        => FastEnum.IsDefined<Fruits, FruitsBooster>(Value);
 }

--- a/src/insights/FastEnum.Benchmarks/Scenarios/ToString_Defined.cs
+++ b/src/insights/FastEnum.Benchmarks/Scenarios/ToString_Defined.cs
@@ -2,7 +2,6 @@
 using BenchmarkDotNet.Attributes;
 using EnumsNET;
 using FastEnumUtility.Benchmarks.Models;
-using _FastEnum = FastEnumUtility.FastEnum;
 
 namespace FastEnumUtility.Benchmarks.Scenarios;
 
@@ -18,7 +17,7 @@ public class ToString_Defined
     {
         _ = Enum.GetNames<Fruits>();
         _ = Enums.GetMembers<Fruits>();
-        _ = _FastEnum.GetMembers<Fruits>();
+        _ = FastEnum.GetMembers<Fruits>();
     }
 
 
@@ -38,6 +37,11 @@ public class ToString_Defined
 
 
     [Benchmark]
-    public string FastEnum()
-        => _FastEnum.ToString<Fruits, FruitsBooster>(Value);
+    public string FastEnum_Reflection()
+        => FastEnum.ToString(Value);
+
+
+    [Benchmark]
+    public string FastEnum_SourceGen()
+        => FastEnum.ToString<Fruits, FruitsBooster>(Value);
 }

--- a/src/insights/FastEnum.Benchmarks/Scenarios/ToString_Undefined.cs
+++ b/src/insights/FastEnum.Benchmarks/Scenarios/ToString_Undefined.cs
@@ -2,7 +2,6 @@
 using BenchmarkDotNet.Attributes;
 using EnumsNET;
 using FastEnumUtility.Benchmarks.Models;
-using _FastEnum = FastEnumUtility.FastEnum;
 
 namespace FastEnumUtility.Benchmarks.Scenarios;
 
@@ -18,7 +17,7 @@ public class ToString_Undefined
     {
         _ = Enum.GetNames<Fruits>();
         _ = Enums.GetMembers<Fruits>();
-        _ = _FastEnum.GetMembers<Fruits>();
+        _ = FastEnum.GetMembers<Fruits>();
     }
 
 
@@ -38,6 +37,11 @@ public class ToString_Undefined
 
 
     [Benchmark]
-    public string FastEnum()
-        => _FastEnum.ToString<Fruits, FruitsBooster>(Value);
+    public string FastEnum_Reflection()
+        => FastEnum.ToString(Value);
+
+
+    [Benchmark]
+    public string FastEnum_SourceGen()
+        => FastEnum.ToString<Fruits, FruitsBooster>(Value);
 }

--- a/src/insights/FastEnum.Benchmarks/Scenarios/TryParse_CaseInsensitive.cs
+++ b/src/insights/FastEnum.Benchmarks/Scenarios/TryParse_CaseInsensitive.cs
@@ -2,7 +2,6 @@
 using BenchmarkDotNet.Attributes;
 using EnumsNET;
 using FastEnumUtility.Benchmarks.Models;
-using _FastEnum = FastEnumUtility.FastEnum;
 
 namespace FastEnumUtility.Benchmarks.Scenarios;
 
@@ -18,7 +17,7 @@ public class TryParse_CaseInsensitive
     {
         _ = Enum.GetNames<Fruits>();
         _ = Enums.GetMembers<Fruits>();
-        _ = _FastEnum.GetMembers<Fruits>();
+        _ = FastEnum.GetMembers<Fruits>();
     }
 
 
@@ -38,6 +37,11 @@ public class TryParse_CaseInsensitive
 
 
     [Benchmark]
-    public bool FastEnum()
-        => _FastEnum.TryParse<Fruits, FruitsBooster>(Value, true, out _);
+    public bool FastEnum_Reflection()
+        => FastEnum.TryParse<Fruits>(Value, true, out _);
+
+
+    [Benchmark]
+    public bool FastEnum_SourceGen()
+        => FastEnum.TryParse<Fruits, FruitsBooster>(Value, true, out _);
 }

--- a/src/insights/FastEnum.Benchmarks/Scenarios/TryParse_CaseSensitive.cs
+++ b/src/insights/FastEnum.Benchmarks/Scenarios/TryParse_CaseSensitive.cs
@@ -2,7 +2,6 @@
 using BenchmarkDotNet.Attributes;
 using EnumsNET;
 using FastEnumUtility.Benchmarks.Models;
-using _FastEnum = FastEnumUtility.FastEnum;
 
 namespace FastEnumUtility.Benchmarks.Scenarios;
 
@@ -18,7 +17,7 @@ public class TryParse_CaseSensitive
     {
         _ = Enum.GetNames<Fruits>();
         _ = Enums.GetMembers<Fruits>();
-        _ = _FastEnum.GetMembers<Fruits>();
+        _ = FastEnum.GetMembers<Fruits>();
     }
 
 
@@ -38,6 +37,11 @@ public class TryParse_CaseSensitive
 
 
     [Benchmark]
-    public bool FastEnum()
-        => _FastEnum.TryParse<Fruits, FruitsBooster>(Value, out _);
+    public bool FastEnum_Reflection()
+        => FastEnum.TryParse<Fruits>(Value, out _);
+
+
+    [Benchmark]
+    public bool FastEnum_SourceGen()
+        => FastEnum.TryParse<Fruits, FruitsBooster>(Value, out _);
 }


### PR DESCRIPTION
This pull request updates the FastEnum benchmark scenarios to distinguish between reflection-based and source generator-based implementations, and removes the use of the `_FastEnum` alias for clarity. The benchmarks now separately measure the performance of both approaches, making it easier to compare them.
