### PR TITLE
Using .NET 10 runtime explicitly

### DIFF
--- a/src/insights/FastEnum.Benchmarks/FastEnum.Benchmarks.csproj
+++ b/src/insights/FastEnum.Benchmarks/FastEnum.Benchmarks.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net10.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <RootNamespace>FastEnumUtility.Benchmarks</RootNamespace>
     </PropertyGroup>

--- a/src/insights/FastEnum.Benchmarks/Internals/BenchmarkConfig.cs
+++ b/src/insights/FastEnum.Benchmarks/Internals/BenchmarkConfig.cs
@@ -1,5 +1,6 @@
 ﻿using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
 
@@ -31,7 +32,7 @@ internal static class BenchmarkConfig
                 exportGithubMarkdown: true,
                 exportCombinedDisassemblyReport: true
             )))
-            .AddJob(job);
+            .AddJob(job.WithRuntime(CoreRuntime.Core10_0));
     }
     #endregion
 }


### PR DESCRIPTION
This pull request updates the benchmark project configuration for `FastEnum.Benchmarks` to explicitly target .NET 10.0 in its benchmark jobs, rather than relying on the project-level target framework. This ensures that benchmarks are run using the intended runtime, regardless of the project's target framework settings.