### PR TITLE
Suppress CA1069 warning

### DIFF
--- a/src/insights/FastEnum.UnitTests/Models/Enums.cs
+++ b/src/insights/FastEnum.UnitTests/Models/Enums.cs
@@ -242,7 +242,9 @@ public enum SameValueContinuousEnum : byte
 {
     A = 1,
     B = 2,
+#pragma warning disable CA1069
     C = 2,  // Name is different, but value is same as other member.
+#pragma warning restore CA1069
     D = 3,
 }
 
@@ -252,7 +254,9 @@ public enum SameValueDiscontinuousEnum : byte
 {
     A = 1,
     B = 3,
+#pragma warning disable CA1069
     C = 3,  // Name is different, but value is same as other member.
+#pragma warning restore CA1069
     D = 5,
 }
 


### PR DESCRIPTION
This pull request updates the enum definitions in the unit test models to explicitly suppress compiler warnings about duplicate enum values. The changes clarify intent and prevent unnecessary warnings during builds.