### PR TITLE
Use `FrozenDictionary<K,V>` in .NET 10 instead of `FastReadOnlyDictionary<K,V>`

### DIFF
--- a/src/libs/FastEnum.Core/Internals/EnumInfo.cs
+++ b/src/libs/FastEnum.Core/Internals/EnumInfo.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if NET10_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -22,7 +25,11 @@ internal static class EnumInfo<T>
     public static readonly Member<T>[] s_orderedMembers;
     public static readonly CaseSensitiveStringDictionary<Member<T>> s_memberByNameCaseSensitive;
     public static readonly CaseInsensitiveStringDictionary<Member<T>> s_memberByNameCaseInsensitive;
+#if NET10_0_OR_GREATER
+    public static readonly FrozenDictionary<T, Member<T>> s_memberByValue;
+#else
     public static readonly FastReadOnlyDictionary<T, Member<T>> s_memberByValue;
+#endif
     public static readonly T s_minValue;
     public static readonly T s_maxValue;
     public static readonly bool s_isContinuous;
@@ -49,7 +56,11 @@ internal static class EnumInfo<T>
             = s_members
             .DistinctBy(static x => x.Name, StringComparer.OrdinalIgnoreCase)
             .ToCaseInsensitiveStringDictionary(static x => x.Name);
+#if NET10_0_OR_GREATER
+        s_memberByValue = s_orderedMembers.ToFrozenDictionary(static x => x.Value);
+#else
         s_memberByValue = s_orderedMembers.ToFastReadOnlyDictionary(static x => x.Value);
+#endif
         s_minValue = s_values.DefaultIfEmpty().Min();
         s_maxValue = s_values.DefaultIfEmpty().Max();
         s_isContinuous = isContinuous(s_memberByValue.Count, s_maxValue, s_minValue);

--- a/src/libs/FastEnum.Core/Member.cs
+++ b/src/libs/FastEnum.Core/Member.cs
@@ -4,7 +4,11 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Text;
+#if NET10_0_OR_GREATER
+using System.Collections.Frozen;
+#else
 using FastEnumUtility.Internals;
+#endif
 
 namespace FastEnumUtility;
 
@@ -52,7 +56,11 @@ public sealed class Member<T>
     /// <summary>
     /// Gets the labels of specified enumration member.
     /// </summary>
+#if NET10_0_OR_GREATER
+    internal FrozenDictionary<int, string?> Labels { get; }
+#else
     internal FastReadOnlyDictionary<int, string?> Labels { get; }
+#endif
     #endregion
 
 
@@ -71,7 +79,11 @@ public sealed class Member<T>
         this.Labels
             = this.FieldInfo
             .GetCustomAttributes<LabelAttribute>()
+#if NET10_0_OR_GREATER
+            .ToFrozenDictionary(static x => x.Index, static x => x.Value);
+#else
             .ToFastReadOnlyDictionary(static x => x.Index, static x => x.Value);
+#endif
     }
 
 


### PR DESCRIPTION
# Summary
.NET 10 introduces performance improvements to `FrozenDictionary<TKey, TValue>` for integer and enum keys.
As a result, our custom read-only dictionary implementation, `FastReadOnlyDictionary<TKey, TValue>`, is now slower than `FrozenDictionary<TKey, TValue>`. When targeting .NET 10 or later, we should stop using `FastReadOnlyDictionary<TKey, TValue>` and use `FrozenDictionary<TKey, TValue>` instead.

- https://github.com/dotnet/runtime/pull/111886


# Benchmark results
## .NET 9
```md
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8737/25H2/2025Update/HudsonValley2)
Intel Core Ultra 7 155H 3.00GHz, 1 CPU, 22 logical and 16 physical cores
.NET SDK 10.0.301
  [Host]     : .NET 8.0.28 (8.0.28, 8.0.2826.26413), X64 RyuJIT x86-64-v3
  Job-YNJDZW : .NET 9.0.17 (9.0.17, 9.0.1726.26416), X64 RyuJIT x86-64-v3

Runtime=.NET 9.0

| Method                         | Mean      | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------------------- |----------:|----------:|----------:|------:|--------:|----------:|------------:|
| EnumKey_FrozenDictionary       | 21.421 ns | 0.4159 ns | 0.3891 ns |  1.00 |    0.03 |         - |          NA |
| EnumKey_FastReadOnlyDictionary |  9.751 ns | 0.1629 ns | 0.1524 ns |  0.46 |    0.01 |         - |          NA |
```

## .NET 10
```md
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8737/25H2/2025Update/HudsonValley2)
Intel Core Ultra 7 155H 3.00GHz, 1 CPU, 22 logical and 16 physical cores
.NET SDK 10.0.301
  [Host]     : .NET 8.0.28 (8.0.28, 8.0.2826.26413), X64 RyuJIT x86-64-v3
  Job-GVKUBM : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3

Runtime=.NET 10.0

| Method                         | Mean      | Error     | StdDev    | Median    | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------------------- |----------:|----------:|----------:|----------:|------:|--------:|----------:|------------:|
| EnumKey_FrozenDictionary       |  5.568 ns | 0.2847 ns | 0.8395 ns |  4.948 ns |  1.02 |    0.21 |         - |          NA |
| EnumKey_FastReadOnlyDictionary | 14.321 ns | 1.3043 ns | 3.8459 ns | 13.473 ns |  2.63 |    0.80 |         - |          NA |
```