### PR TITLE
Update NuGet packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,8 +6,8 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Enums.NET" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-    <PackageVersion Include="MSTest" Version="4.2.3" />
-    <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta16" />
+    <PackageVersion Include="MSTest" Version="4.3.0" />
+    <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta21" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/insights/FastEnum.Benchmarks/FastEnum.Benchmarks.csproj
+++ b/src/insights/FastEnum.Benchmarks/FastEnum.Benchmarks.csproj
@@ -8,11 +8,7 @@
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" />
         <PackageReference Include="Enums.NET" />
-        <PackageReference Include="NetEscapades.EnumGenerators">
-            <PrivateAssets>all</PrivateAssets>
-            <ExcludeAssets>runtime</ExcludeAssets>
-            <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="NetEscapades.EnumGenerators" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request updates package dependencies to newer versions and simplifies package reference configuration in the `FastEnum.Benchmarks` project.

Dependency updates:

* Upgraded `MSTest` from version `4.2.3` to `4.3.0` in `Directory.Packages.props` to ensure the latest testing features and fixes.
* Upgraded `NetEscapades.EnumGenerators` from version `1.0.0-beta16` to `1.0.0-beta21` in `Directory.Packages.props` for improved enum source generation support.

Project file simplification:

* Simplified the `NetEscapades.EnumGenerators` package reference in `FastEnum.Benchmarks.csproj` by removing explicit asset configuration, relying on default behavior instead.